### PR TITLE
Allow a Secret to be used as credentials store through Helm chart

### DIFF
--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -54,4 +54,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      {{ if ne .Values.aws.credentialsSecretName "" }}
+        volumeMounts:
+        - name: creds-secret-volume
+          readOnly: true
+          mountPath: "/root/.aws"
+      volumes:
+      - name: creds-secret-volume
+        secret:
+          secretName: {{ .Values.aws.credentialsSecretName }}
+      {{ end }}
       terminationGracePeriodSeconds: 10

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -26,6 +26,7 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
+  credentialsSecretName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Description of changes: This PR allows people to use `Secret` that contains the usual AWS CLI configuration file found in `~/.aws/credentials` as the credential store for ACK controllers. The expected format of the `Secret` is:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: aws-account-creds
  namespace: ack-system
type: Opaque
data:
  credentials: ${BASE64ENCODED_AWS_ACCOUNT_CREDS}
``` 

One can generate `BASE64ENCODED_AWS_ACCOUNT_CREDS` via:
```console
BASE64ENCODED_AWS_ACCOUNT_CREDS=$(echo "[default]\naws_access_key_id = $(aws configure get aws_access_key_id --profile $aws_profile)\naws_secret_access_key = $(aws configure get aws_secret_access_key --profile $aws_profile)\nregion = $(aws configure get region --profile $aws_profile)" | base64  | tr -d "\n")
```

Currently, this is not working since `AWS_ACCOUNT_ID` and `AWS_REGION` env vars have to be set in `Pod`. Once they are made optional, this will be working in cases where they are not given.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
