### PR TITLE
Elasticache: initial support for User

### DIFF
--- a/services/elasticache/apis/v1alpha1/user.go
+++ b/services/elasticache/apis/v1alpha1/user.go
@@ -44,10 +44,12 @@ type UserStatus struct {
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
-	Conditions     []*ackv1alpha1.Condition `json:"conditions"`
-	Authentication *Authentication          `json:"authentication,omitempty"`
-	Status         *string                  `json:"status,omitempty"`
-	UserGroupIDs   []*string                `json:"userGroupIDs,omitempty"`
+	Conditions              []*ackv1alpha1.Condition `json:"conditions"`
+	Authentication          *Authentication          `json:"authentication,omitempty"`
+	LastAppliedAccessString *string                  `json:"lastAppliedAccessString,omitempty"`
+	ResponseAccessString    *string                  `json:"responseAccessString,omitempty"`
+	Status                  *string                  `json:"status,omitempty"`
+	UserGroupIDs            []*string                `json:"userGroupIDs,omitempty"`
 }
 
 // User is the Schema for the Users API

--- a/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
@@ -3637,6 +3637,16 @@ func (in *UserStatus) DeepCopyInto(out *UserStatus) {
 		*out = new(Authentication)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LastAppliedAccessString != nil {
+		in, out := &in.LastAppliedAccessString, &out.LastAppliedAccessString
+		*out = new(string)
+		**out = **in
+	}
+	if in.ResponseAccessString != nil {
+		in, out := &in.ResponseAccessString, &out.ResponseAccessString
+		*out = new(string)
+		**out = **in
+	}
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
 		*out = new(string)

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_users.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_users.yaml
@@ -123,6 +123,10 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedAccessString:
+                type: string
+              responseAccessString:
+                type: string
               status:
                 type: string
               userGroupIDs:

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -98,6 +98,28 @@ resources:
           path: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
+  User:
+    exceptions:
+      terminal_codes:
+        - UserAlreadyExists
+        - UserQuotaExceeded
+        - DuplicateUserName
+        - InvalidParameterValue
+        - InvalidParameterCombination
+        - InvalidUserState
+        - UserNotFound
+        - DefaultUserAssociatedToUserGroup
+    fields:
+      LastAppliedAccessString:
+        is_read_only: true
+        from:
+          operation: CreateUser
+          path: AccessString
+      ResponseAccessString:
+        is_read_only: true
+        from:
+          operation: CreateUser
+          path: AccessString
 operations:
   DescribeCacheSubnetGroups:
     set_output_custom_method_name: CustomDescribeCacheSubnetGroupsSetOutput
@@ -119,6 +141,11 @@ operations:
     set_output_custom_method_name: CustomCreateCacheParameterGroupSetOutput
   DescribeCacheParameterGroups:
     set_output_custom_method_name: CustomDescribeCacheParameterGroupsSetOutput
+  CreateUser:
+    set_output_custom_method_name: CustomCreateUserSetOutput
+  ModifyUser:
+    custom_implementation: CustomModifyUser
+    set_output_custom_method_name: CustomModifyUserSetOutput
 ignore:
   resource_names:
     - GlobalReplicationGroup

--- a/services/elasticache/pkg/resource/user/custom_set_output.go
+++ b/services/elasticache/pkg/resource/user/custom_set_output.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package user
+
+import (
+	"context"
+
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/elasticache/apis/v1alpha1"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+// set the custom Status fields upon creation
+func (rm *resourceManager) CustomCreateUserSetOutput(
+	ctx context.Context,
+	r *resource,
+	resp *elasticache.CreateUserOutput,
+	ko *svcapitypes.User,
+) (*svcapitypes.User, error) {
+	return rm.CustomSetOutput(r, resp.AccessString, ko)
+}
+
+// precondition: successful ModifyUserWithContext call
+// By updating 'latest' Status fields, these changes should be applied to 'desired'
+// upon patching
+func (rm *resourceManager) CustomModifyUserSetOutput(
+	ctx context.Context,
+	r *resource,
+	resp *elasticache.ModifyUserOutput,
+	ko *svcapitypes.User,
+) (*svcapitypes.User, error) {
+	return rm.CustomSetOutput(r, resp.AccessString, ko)
+}
+
+func (rm *resourceManager) CustomSetOutput(
+	r *resource,
+	responseAccessString *string,
+	ko *svcapitypes.User,
+) (*svcapitypes.User, error) {
+
+	lastApplied := *r.ko.Spec.AccessString
+	ko.Status.LastAppliedAccessString = &lastApplied
+
+	responseAccessStringValue := *responseAccessString
+	ko.Status.ResponseAccessString = &responseAccessStringValue
+
+	return ko, nil
+}

--- a/services/elasticache/pkg/resource/user/custom_update_api.go
+++ b/services/elasticache/pkg/resource/user/custom_update_api.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package user
+
+import (
+	"context"
+	"github.com/pkg/errors"
+
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	"github.com/aws/aws-controllers-k8s/pkg/requeue"
+)
+
+// If a requeue is needed or the access string needs to be modified, execute the necessary actions.
+// If not, return (nil, nil), which defers to the generated code in SdkUpdate.
+func (rm *resourceManager) CustomModifyUser(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+
+	// requeue if necessary
+	latestStatus := latest.ko.Status.Status
+	if latestStatus == nil || *latestStatus != "active" {
+		return nil, requeue.NeededAfter(
+			errors.New("User cannot be modified as its status is not 'available'."),
+			requeue.DefaultRequeueAfterDuration)
+	}
+
+	// no recent change in desired access string; do nothing and return 'latest' unmodified
+	if *desired.ko.Spec.AccessString == *desired.ko.Status.LastAppliedAccessString {
+		return latest, nil
+	}
+
+	// desired access string changed; defer to generated code in SdkUpdate and rely on
+	// custom set output to update last applied/response access strings
+	return nil, nil
+}

--- a/test/e2e/elasticache/__init__.py
+++ b/test/e2e/elasticache/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+SERVICE_NAME = "elasticache"
+CRD_GROUP = "elasticache.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+# PyTest marker for the current service
+service_marker = pytest.mark.service(arg=SERVICE_NAME)

--- a/test/e2e/elasticache/resources/user.yaml
+++ b/test/e2e/elasticache/resources/user.yaml
@@ -1,0 +1,11 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: User
+metadata:
+  name: $USER_ID
+spec:
+  accessString: $ACCESS_STRING
+  engine: redis
+  passwords:
+    - testplaintextpassword
+  userID: $USER_ID
+  userName: $USER_ID

--- a/test/e2e/elasticache/tests/__init__.py
+++ b/test/e2e/elasticache/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/e2e/elasticache/tests/test_user.py
+++ b/test/e2e/elasticache/tests/test_user.py
@@ -1,0 +1,82 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""CRUD tests for the Elasticache User resource
+"""
+
+import boto3
+import botocore
+import pytest
+
+from time import sleep
+from elasticache import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from common.resources import load_resource_file, random_suffix_name
+from common import k8s
+
+RESOURCE_PLURAL = "users"
+DEFAULT_WAIT_SECS = 90
+
+@pytest.fixture(scope="module")
+def elasticache_client():
+    return boto3.client("elasticache")
+
+# set up input parameters for User
+@pytest.fixture(scope="module")
+def input_dict():
+    resource_name = random_suffix_name("test-user", 32)
+    input_dict = {
+        "USER_ID": resource_name,
+        "ACCESS_STRING": "on ~app::* -@all +@read"
+    }
+    return input_dict
+
+@pytest.fixture(scope="module")
+def user(input_dict, elasticache_client):
+
+    # inject parameters into yaml; create User in cluster
+    user = load_resource_file(
+        SERVICE_NAME, "user", additional_replacements=input_dict)
+    reference = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, input_dict["USER_ID"], namespace="default")
+    _ = k8s.create_custom_resource(reference, user)
+    resource = k8s.wait_resource_consumed_by_controller(reference)
+    assert resource is not None
+    yield (reference, resource)
+
+    # teardown: delete in k8s, assert user does not exist in AWS
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    with pytest.raises(botocore.exceptions.ClientError, match="UserNotFound"):
+        _ = elasticache_client.describe_users(UserId=input_dict["USER_ID"])
+
+
+@service_marker
+class TestUser:
+
+    # CRUD test for User; "create" and "delete" operations implicit in "user" fixture
+    def test_CRUD(self, user, input_dict):
+        (reference, resource) = user
+        assert k8s.get_resource_exists(reference)
+
+        resource = k8s.get_resource(reference)
+        assert resource["status"]["lastAppliedAccessString"] == input_dict["ACCESS_STRING"]
+        assert resource["status"]["status"] == "active"
+
+        new_access_string = "on ~app::* -@all +@read +@write"
+        user_patch = {"spec": {"accessString": new_access_string}}
+        _ = k8s.patch_custom_resource(reference, user_patch)
+        assert k8s.wait_resource_status_desired(reference, "active", wait_periods=3)
+
+        resource = k8s.get_resource(reference)
+        assert resource["status"]["lastAppliedAccessString"] == new_access_string
+        assert resource["status"]["status"] == "active"


### PR DESCRIPTION
Description of changes:

- Terminal codes
- Additional `Status` fields for statekeeping: Elasticache's CreateUser and ModifyUser operations return an AccessString in a different representation than the AccessString requested by the user. We have to compensate for this in some way, as the generated code does not handle this case. The current solution is to add a `Status.LastAppliedAccessString` to determine when the desired AccessString has changed and `Status.ResponseAccessString` so that the user can see the server representation of the AccessString (without using the AWS CLI). Another possible solution would be to allow patching to apply to an object's `Spec` field, although if I'm not mistaken this was explicitly disabled in an earlier PR.
- Custom set output and modify logic to populate these additional `Status` fields and use them to determine when to invoke a ModifyUser versus when to do nothing.

Behavior verified via manual testing; automated tests and other changes to follow in later PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
