### PR TITLE
Add support for non-default AWS profile

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -21,9 +21,10 @@ DEFAULT_AWS_CLI_VERSION="2.0.52"
 # To use a specific version of the AWS CLI, set the ACK_AWS_CLI_IMAGE_VERSION
 # environment variable, otherwise the value of DEFAULT_AWS_CLI_VERSION is used.
 daws() {
+    aws_cli_profile_env=$([ ! -z "$AWS_PROFILE" ] && echo "--env AWS_PROFILE=$AWS_PROFILE")
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
-    docker run --rm -v ~/.aws:/root/.aws:z  -v $(pwd):/aws "$aws_cli_img" "$@"
+    docker run --rm -v ~/.aws:/root/.aws:z $(echo $aws_cli_profile_env) -v $(pwd):/aws "$aws_cli_img" "$@"
 }
 
 # aws_check_credentials() calls the STS::GetCallerIdentity API call and


### PR DESCRIPTION
Description of changes:
Currently, the kind-test uses the `daws` script to run AWS cli commands. However, it does not respect $AWS_PROFILE, and instead always uses default.

This pull request changes it, such that if $AWS_PROFILE is set, it will be passed as an environment variable to the Docker run.

There is a tiny bit of wonkiness so that it does not pass anything when $AWS_PROFILE is not set - because in testing, I could not get the --profile option (which may never be used in this setting, either way) to override the environment variable even if it's set to empty.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
