### PR TITLE
fix: update all doc URLs to point to new URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 ## Developer documentation
-[See the documentation](https://aws.github.io/aws-controllers-k8s/dev-docs/overview/) for detailed development information.
+[See the documentation](https://aws-controllers-k8s.github.io/community/dev-docs/overview/) for detailed development information.
 
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 # AWS Controllers for Kubernetes (ACK)
 **AWS Controllers for Kubernetes (ACK)** lets you define and use AWS service resources directly from Kubernetes. With ACK, you can take advantage of AWS managed services for your Kubernetes applications without needing to define resources outside of the cluster or run services that provide supporting capabilities like databases or message queues within the cluster.
 
-This is a new open source project built with ❤️ by AWS and available as a **Developer Preview**. We encourage you to [try it out](https://aws.github.io/aws-controllers-k8s/dev-docs/testing/), provide feedback and contribute to development.
+This is a new open source project built with ❤️ by AWS and available as a **Developer Preview**. We encourage you to [try it out](https://aws-controllers-k8s.github.io/community/dev-docs/testing/), provide feedback and contribute to development.
 
 > **IMPORTANT** Because this project is in developer preview, you may see breaking changes throughout. We encourage you to experiment with ACK but DO NOT adopt it for production use. Use of ACK controllers in preview is subject to the terms and conditions contained in the [AWS Service Terms](https://aws.amazon.com/service-terms), particularly the Beta Service Participation Service Terms, and apply to any service controllers not marked as 'Generally Available'.
 
@@ -32,12 +32,12 @@ ACK is a collection of Kubernetes [custom resource definitions](https://kubernet
 
 ## Getting Started
 
-Until we've graduated ACK [service controllers](https://aws.github.io/aws-controllers-k8s/services/) we ask you to [test-drive](https://aws.github.io/aws-controllers-k8s/dev-docs/testing/) them.
+Until we've graduated ACK [service controllers](https://aws-controllers-k8s.github.io/community/services/) we ask you to [test-drive](https://aws-controllers-k8s.github.io/community/dev-docs/testing/) them.
 
 ## Help & Feedback
 For help, please consider the following venues (in order):
 
-* [ACK project documentation](https://aws.github.io/aws-controllers-k8s/)
+* [ACK project documentation](https://aws-controllers-k8s.github.io/community/)
 * [Search open issues](https://github.com/aws-controllers-k8s/community/issues)
 * [File an issue](https://github.com/aws-controllers-k8s/community/issues/new/choose)
 * Chat with us on the `#provider-aws` channel in the [Kubernetes Slack](https://kubernetes.slack.com/) community.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,40 +1,40 @@
-🟩 [View the live docs](https://aws.github.io/aws-controllers-k8s/)
+🟩 [View the live docs](https://aws-controllers-k8s.github.io/community/)
 
 # Writing and publishing docs
 
-Our docs are written in [MkDocs](https://www.mkdocs.org/) using the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme. 
+Our docs are written in [MkDocs](https://www.mkdocs.org/) using the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme.
 
-MkDocs is a static site generator. It converts markdown files to static html pages. Edit the markdown files, and view the rendered site with MkDocs. 
+MkDocs is a static site generator. It converts markdown files to static html pages. Edit the markdown files, and view the rendered site with MkDocs.
 
-## Automatic deployments with github actions 
+## Automatic deployments with github actions
 
-Commits that change a file under the `docs/` directory trigger a github action to build the site, and deploy it to github pages. 
+Commits that change a file under the `docs/` directory trigger a github action to build the site, and deploy it to github pages.
 
 The github action is [mkdocs-deploy-gh-pages](https://github.com/mhausenblas/mkdocs-deploy-gh-pages).
 
-🟧 Running `mkdocs gh-deploy` locally will have no effect, the github action will overwrite it. 
+🟧 Running `mkdocs gh-deploy` locally will have no effect, the github action will overwrite it.
 
 ## Build the docs locally
 
 ### Install mkdocs-material
 
-🟧 The ACK docs require the mkdocs-material theme. 
+🟧 The ACK docs require the mkdocs-material theme.
 
 To ensure you are using a compatible version of mkdocs and the mkdocs-material theme, use a python virtual environment. Then, install mkdocs-material.
 
 ```
-python3 -m venv venv 
+python3 -m venv venv
 source venv/bin/activate
 pip install mkdocs-material
 ```
 
 Visit the python docs to learn more about [virutal environments (venv)](https://docs.python.org/3/library/venv.html).
 
-Optionally, use a global `.gitignore` to hide the `venv` directory. 
+Optionally, use a global `.gitignore` to hide the `venv` directory.
 
-### Local preview 
+### Local preview
 
-🟧 Test locally, including both the content and the navigation structure. 
+🟧 Test locally, including both the content and the navigation structure.
 
 The docs are just Markdown files and in order to see the rendered preview locally (before PRing the repo), do:
 
@@ -53,7 +53,7 @@ WARNING -  A relative path to 'discussions.md' is included in the 'nav' configur
 
 Problems with the local preview? Check the [Material for MkDocs changelog](https://squidfunk.github.io/mkdocs-material/upgrading/).
 
-### Writing 
+### Writing
 
 The [MkDocs reference](https://www.mkdocs.org/user-guide/writing-your-docs/) includes information on the structure of the `docs/` folder, and writing in markdown.
 

--- a/docs/contents/dev-docs/api-inference.md
+++ b/docs/contents/dev-docs/api-inference.md
@@ -80,7 +80,7 @@ structure of the AWS service API, including a set of *Operation* definitions
 (commonly called "Actions" in the official AWS API documentation) and a set of
 *Shape* definitions.
 
-[codegen]: https://aws.github.io/aws-controllers-k8s/dev-docs/code-generation/
+[codegen]: https://aws-controllers-k8s.github.io/community/dev-docs/code-generation/
 
 Some AWS APIs have dozens (hundreds even!) of Operations exposed by the API.
 Consider EC2's API. It has over **400 separate Actions**. Out of all those
@@ -517,7 +517,7 @@ Account ID is the 12-digit AWS account ID that is billed for the resource.
     AWS Account ID of the IAM Role that the ACK service controller is executing
     under.
 
-[carm]: https://aws.github.io/aws-controllers-k8s/user-docs/authorization/#create-resource-in-different-aws-accounts
+[carm]: https://aws-controllers-k8s.github.io/community/user-docs/authorization/#create-resource-in-different-aws-accounts
 
 The `Conditions` field is also included in every ACK CRD's Status field. It is
 a slice of pointers to [`ackv1alpha1.Condition`][ack-cond] structs. The

--- a/docs/contents/dev-docs/overview.md
+++ b/docs/contents/dev-docs/overview.md
@@ -19,7 +19,7 @@ resources in a specific AWS API.
 
 The `github.com/aws-controllers-k8s/community` source code repository (this
 repo) contains the common test scripts and documentation that gets published to
-https://aws.github.io/aws-controllers-k8s/.
+https://aws-controllers-k8s.github.io/community/.
 
 ### `github.com/aws-controllers-k8s/runtime`
 
@@ -53,7 +53,7 @@ charts for the controller installation (`/helm`).
 Read about [how the code generator infers][api-inference] information about a
 Kubernetes Custom Resource Definitions (CRDs) from an AWS API model file.
 
-[api-inference]: https://aws.github.io/aws-controllers-k8s/dev-docs/api-inference/
+[api-inference]: https://aws-controllers-k8s.github.io/community/dev-docs/api-inference/
 
 ## Code Generation
 

--- a/docs/contents/how-it-works.md
+++ b/docs/contents/how-it-works.md
@@ -43,7 +43,7 @@ the Kubernetes API server to update `(7)` the CR's [`Status`][spec-status] with
 information it received from S3.
 
 [api-kind]: https://kubernetes.io/docs/reference/using-api/api-concepts/#standard-api-terminology
-[authz]: https://aws.github.io/aws-controllers-k8s/user-docs/authorization/
+[authz]: https://aws-controllers-k8s.github.io/community/user-docs/authorization/
 [pod]: https://kubernetes.io/docs/concepts/workloads/pods/
 [manifest]: https://kubernetes.io/docs/reference/glossary/?all=true#term-manifest
 [controller]: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-controller

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -52,13 +52,13 @@ Read more about [how ACK works][how-it-works].
 [gh]: https://github.com/aws/aws-controllers-k8s/
 [controller]: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-controller
 [crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[how-it-works]: https://aws.github.io/aws-controllers-k8s/how-it-works/
+[how-it-works]: https://aws-controllers-k8s.github.io/community/how-it-works/
 
 ## Getting started
 
-Until we've graduated ACK [service controllers][services] we ask you to [test-drive](https://aws.github.io/aws-controllers-k8s/dev-docs/testing/) them.
+Until we've graduated ACK [service controllers][services] we ask you to [test-drive](https://aws-controllers-k8s.github.io/community/dev-docs/testing/) them.
 
-[services]: https://aws.github.io/aws-controllers-k8s/services/
+[services]: https://aws-controllers-k8s.github.io/community/services/
 
 ## Getting help
 

--- a/services/README.md
+++ b/services/README.md
@@ -13,7 +13,7 @@ to change about a particular service controller.
 
 ## Supported services
 
-See the [documentation](https://aws.github.io/aws-controllers-k8s/services) for a list of supported services.
+See the [documentation](https://aws-controllers-k8s.github.io/community/services) for a list of supported services.
 
 ### Adding a service controller
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
As the repo name has changed this has caused all the Doc URLs to also change. This updates all references in the repo to point to the new URL.

NOTE: The URL referenced in the GitHub repo (on the right) also needs updating by someone with permission to do so.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
