### PR TITLE
Allow reference to local runtime module from service controller go.mod file during kind-test

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,60 @@
+# Build the manager binary
+FROM golang:1.14.1 as builder
+
+ARG service_alias
+# The tuple of controller image version information
+ARG service_controller_git_version
+ARG service_controller_git_commit
+ARG build_date
+# The directory within the builder container into which we will copy our
+# service controller code.
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR $work_dir
+# For building Go Module required
+ENV GOPROXY=https://proxy.golang.org,direct
+ENV GO111MODULE=on
+ENV GOARCH=amd64
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version
+# Copy the Go Modules manifests and LICENSE/ATTRIBUTION
+COPY $service_alias-controller/LICENSE $work_dir/LICENSE
+COPY $service_alias-controller/ATTRIBUTION.md $work_dir/ATTRIBUTION.md
+# use local mod files
+COPY $service_alias-controller/go.local.mod $work_dir/go.local.mod
+COPY $service_alias-controller/go.local.sum $work_dir/go.local.sum
+COPY $service_alias-controller/go.mod $work_dir/go.mod
+
+# for local development, copy local runtime repo
+COPY runtime/pkg $work_dir/../runtime/pkg
+COPY runtime/apis $work_dir/../runtime/apis
+COPY runtime/go.mod $work_dir/../runtime/go.mod
+COPY runtime/go.sum $work_dir/../runtime/go.sum
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+WORKDIR $work_dir/../runtime
+RUN  go mod download
+WORKDIR $work_dir
+RUN  go mod download
+
+# Now copy the go source code for the service controller...
+COPY $service_alias-controller/apis $work_dir/apis
+COPY $service_alias-controller/cmd $work_dir/cmd
+COPY $service_alias-controller/pkg $work_dir/pkg
+# Build
+RUN GIT_VERSION=$service_controller_git_version && \
+    GIT_COMMIT=$service_controller_git_commit && \
+    BUILD_DATE=$build_date && \
+    go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
+    -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
+    -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -modfile="${work_dir}/go.local.mod" \
+    -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
+
+FROM amazonlinux:2
+ARG service_alias
+ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
+WORKDIR /
+COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
+ENTRYPOINT ["/bin/controller"]

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,12 @@ test: | mocks	## Run code tests
 clean-mocks:	## Remove mocks directory
 	rm -rf mocks
 
+build-controller-image: export LOCAL_MODULES = false
 build-controller-image:	## Build container image for SERVICE
+	@./scripts/build-controller-image.sh $(AWS_SERVICE)
+
+local-build-controller-image: export LOCAL_MODULES = true
+local-build-controller-image:	## Build container image for SERVICE allowing local modules
 	@./scripts/build-controller-image.sh $(AWS_SERVICE)
 
 publish-controller-image:  ## docker push a container image for SERVICE
@@ -57,7 +62,13 @@ build-controller: build-ack-generate ## Generate controller code for SERVICE
 	@./scripts/build-controller.sh $(AWS_SERVICE)
 
 kind-test: export PRESERVE = true
+kind-test: export LOCAL_MODULES = false
 kind-test: ## Run functional tests for SERVICE with AWS_ROLE_ARN
+	@./scripts/kind-build-test.sh $(AWS_SERVICE)
+
+local-kind-test: export PRESERVE = true
+local-kind-test: export LOCAL_MODULES = true
+local-kind-test: ## Run functional tests for SERVICE with AWS_ROLE_ARN allowing local modules
 	@./scripts/kind-build-test.sh $(AWS_SERVICE)
 
 delete-all-kind-clusters:	## Delete all local kind clusters

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -23,6 +23,7 @@ ACK_RESOURCE_TAGS='services.k8s.aws/managed=true, services.k8s.aws/created=%UTCN
 DELETE_CLUSTER_ARGS=""
 K8S_VERSION=${K8S_VERSION:-"1.16"}
 PRESERVE=${PRESERVE:-"false"}
+LOCAL_MODULES=${LOCAL_MODULES:-"false"}
 START=$(date +%s)
 # VERSION is the source revision that executables and images are built from.
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
@@ -83,6 +84,8 @@ Environment variables:
   AWS_ROLE_ARN:             Provide AWS Role ARN for functional testing on local KinD Cluster. Mandatory.
   PRESERVE:                 Preserve kind k8s cluster for inspection (<true|false>)
                             Default: false
+  LOCAL_MODULES:            Enables use of local modules during AWS Service controller docker image build
+                            Default: false
   AWS_SERVICE_DOCKER_IMG:   Provide AWS Service docker image
                             Default: aws-controllers-k8s:$AWS_SERVICE-$VERSION
   TMP_DIR                   Cluster context directory, if operating on an existing cluster
@@ -135,6 +138,7 @@ if [ -z "$AWS_SERVICE_DOCKER_IMG" ]; then
     echo -n "building $DEFAULT_AWS_SERVICE_DOCKER_IMG docker image ... "
     AWS_SERVICE_DOCKER_IMG="${DEFAULT_AWS_SERVICE_DOCKER_IMG}"
     export AWS_SERVICE_DOCKER_IMG
+    export LOCAL_MODULES
     ${SCRIPTS_DIR}/build-controller-image.sh ${AWS_SERVICE} 1>/dev/null || exit 1
     echo "ok."
 else


### PR DESCRIPTION
Issue #, if available:

During development, workspace directory setup looks like:
Example setup including ElastiCache service controller along with ACK packages:
```
aws-controllers-k8s
├── code-generator
├── community
├── elasticache-controller
└── runtime
```
To build service controller image against local changes in ```runtime``` module, `elasticache-controller/go.mod` file contains:
```
replace github.com/aws-controllers-k8s/runtime => ../runtime
```

However to run local kind tests (using ```SERVICE=elasticache make kind-test``` from `community` directory) , the controller docker image needs to be built by referring to local `runtime` module from the Dockerfile.

Description of changes:

Created a ```Dockerfile.localmodules``` file that refers ```runtime``` module during build/
Updated ```community/scripts/build-controller-image.sh``` to use ```Dockerfile.localmodules``` if local workspace contains ```runtime``` module.

Note: It is upto the `elasticache-controller/go.mod` to use `runtime` module from local workspace or from its github version; ```Dockerfile.localmodules``` just makes it available during built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
