### PR TITLE
Add codeowners for the SageMaker E2E test directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Please see documentation of use of CODEOWNERS file at
+# https://help.github.com/articles/about-codeowners/ and
+# https://github.com/blog/2392-introducing-code-owners
+
+# Amazon SageMaker CodeOwners
+/test/e2e/sagemaker @akartsky @jkuruba @mbaijal @RedbackThomson @surajkota


### PR DESCRIPTION
### Description of changes:
Added a simple codeowners file which - 
 - Currently, will notify the owners in case of changes to any of the directories they own
 - [TODO] Can be used to gate code merge on a review from a code owner by [enabling this setting on a protected branch](https://github.blog/2017-07-06-introducing-code-owners/#an-extra-layer-of-code-security). 
 - Currently, cross org teams cannot be used as codeowners, so until we create teams within this new org, added members individually. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
