### PR TITLE
fix up build scripts to deal with deleted go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,19 @@ ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV VERSION_PKG=github.com/aws-controllers-k8s/$service_alias-controller/pkg/version
 # Copy the Go Modules manifests and LICENSE/ATTRIBUTION
-COPY LICENSE $work_dir/LICENSE
-COPY ATTRIBUTION.md $work_dir/ATTRIBUTION.md
-COPY go.mod $work_dir/go.mod
-COPY go.sum $work_dir/go.sum
+COPY $service_alias-controller/LICENSE $work_dir/LICENSE
+COPY $service_alias-controller/ATTRIBUTION.md $work_dir/ATTRIBUTION.md
+# Copy Go mod files
+COPY $service_alias-controller/go.mod $work_dir/go.mod
+COPY $service_alias-controller/go.sum $work_dir/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN  go mod download
+RUN go mod download
 
 # Now copy the go source code for the controller...
-COPY apis $work_dir/apis
-COPY cmd $work_dir/cmd
-COPY pkg $work_dir/pkg
+COPY $service_alias-controller/apis $work_dir/apis
+COPY $service_alias-controller/cmd $work_dir/cmd
+COPY $service_alias-controller/pkg $work_dir/pkg
 # Build
 RUN GIT_VERSION=$service_controller_git_version && \
     GIT_COMMIT=$service_controller_git_commit && \

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -76,11 +76,9 @@ fi
 
 # if local build
 # then use Dockerfile which allows references to local modules from service controller
+DOCKER_BUILD_CONTEXT="$ACK_DIR"
 if [[ "$LOCAL_MODULES" = "true" ]]; then
-  DOCKER_BUILD_CONTEXT="$ACK_DIR"
   DOCKERFILE="${ROOT_DIR}"/Dockerfile.local
-else
-  DOCKER_BUILD_CONTEXT="$SERVICE_CONTROLLER_SOURCE_PATH"
 fi
 
 docker build \

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -123,7 +123,12 @@ if [ -z "$ACK_GENERATE_CONFIG_PATH" ]; then
 fi
 
 helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
-ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR"
+# The --aws-sdk-version-go 1.35.5 is a hack here to prevent ack-generate
+# from looking for a go.mod file in the local working directory. It does
+# not affect the release artifacts produced from `ack-generate release`.
+# TODO(jaypipes): Clean this up so the `ack-generate release` command
+# doesn't need to look up a go.mod file for aws-sdk-go version.
+ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-version-go 1.35.5"
 if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
     ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
 fi


### PR DESCRIPTION
After removing the top-level go.mod/sum files, the
`scripts/build-controller-image.sh` and
`scripts/build-controller-release.sh` scripts were broken.

In the case of `build-controller-image.sh`, we needed to always set the
Docker build context to the top-level
`$GOPATH/src/github.com/aws-controllers-k8s` directory and update the
Dockerfile to always copy the go.mod and go.sum files from the service
controller's repository instead of the old go.mod/sum files from the
original monorepo.

In the case of `build-controller-release.sh`, we needed to pass a
`--aws-sdk-go-version` CLI argument to the `ack-generate release`
command line call to force `ack-generate` to not look for a go.mod file
in order to determine the aws-sdk-go version to use in constructing the
SDK helper for the code generator. In the case of the `ack-generate
release` command, we don't actually use the aws-sdk-go contents like we
do for `ack-generate apis` and `ack-generate controller`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
