### PR TITLE
fix incorrect ack-generate flag

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -128,7 +128,7 @@ helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
 # not affect the release artifacts produced from `ack-generate release`.
 # TODO(jaypipes): Clean this up so the `ack-generate release` command
 # doesn't need to look up a go.mod file for aws-sdk-go version.
-ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-version-go 1.35.5"
+ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-go-version 1.35.5"
 if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
     ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
 fi


### PR DESCRIPTION
Made a typo in the fix for the build-controller-release script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
