### PR TITLE
ElastiCache controller e2e test workflow with split repo

### DIFF
--- a/.github/workflows/e2e-test-elasticache.yaml
+++ b/.github/workflows/e2e-test-elasticache.yaml
@@ -1,0 +1,46 @@
+name: e2e-test-elasticache
+on:
+  # Allow manual trigger of e2e tests
+  workflow_dispatch:
+
+jobs:
+  test-elasticache-controller:
+    name: test elasticache controller
+    runs-on: [self-hosted, aws-controllers-k8s]
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+      - name: checkout community code
+        uses: actions/checkout@v2
+        with:
+          path: aws-controllers-k8s/community
+      - name: checkout code-generator code
+        uses: actions/checkout@v2
+        with:
+          repository: aws-controllers-k8s/code-generator
+          path: aws-controllers-k8s/code-generator
+      - name: checkout elasticache-controller code
+        uses: actions/checkout@v2
+        with:
+          repository: aws-controllers-k8s/elasticache-controller
+          path: aws-controllers-k8s/elasticache-controller
+      - name: build ack-generate
+        run: make build-ack-generate
+        working-directory: ./aws-controllers-k8s/community
+      - name: build elasticache controller
+        run: ./scripts/build-controller.sh $SERVICE
+        working-directory: ./aws-controllers-k8s/community
+        env:
+          SERVICE: elasticache
+      - name: execute elasticache e2e tests
+        run: |
+          export TEST_HELM_CHARTS=false
+          export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
+          export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
+          ./scripts/kind-build-test.sh $SERVICE
+        working-directory: ./aws-controllers-k8s/community
+        env:
+          SERVICE: elasticache

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -18,6 +18,7 @@ AWS_REGION=${AWS_REGION:-"us-west-2"}
 AWS_ROLE_ARN=${AWS_ROLE_ARN:-""}
 ACK_ENABLE_DEVELOPMENT_LOGGING="true"
 ENABLE_PROMETHEUS=${ENABLE_PROMETHEUS:-"false"}
+TEST_HELM_CHARTS=${TEST_HELM_CHARTS:-"true"}
 ACK_LOG_LEVEL="debug"
 ACK_RESOURCE_TAGS='services.k8s.aws/managed=true, services.k8s.aws/created=%UTCNOW%, services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%'
 DELETE_CLUSTER_ARGS=""
@@ -233,7 +234,9 @@ if [[ "$ENABLE_PROMETHEUS" == true ]]; then
     k8_wait_for_pod_status "prometheus-deployment" "Running" 60 || (echo 'FAIL: prometheus-deployment failed to Run' && exit 1)
 fi
 
-$TEST_RELEASE_DIR/test-helm.sh "$AWS_SERVICE" "$VERSION"
+if [[ "$TEST_HELM_CHARTS" == true ]]; then
+  $TEST_RELEASE_DIR/test-helm.sh "$AWS_SERVICE" "$VERSION"
+fi
 
 # Fork E2E tests based on bash or Python
 service_test_dir="$TEST_E2E_DIR/$AWS_SERVICE"


### PR DESCRIPTION
Issue #, if available:

* Add unit test workflow for ElastiCache using the split repositories.

Description of changes:

* Added unit test workflow for ElastiCache using the split repositories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
