### PR TITLE
releases, project stages and maintenance phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/aws-controllers-k8s/community/issues)
 ![GitHub issues](https://img.shields.io/github/issues-raw/aws-controllers-k8s/community?style=flat)
 ![GitHub](https://img.shields.io/github/license/aws-controllers-k8s/community?style=flat)
-
-
-![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/aws-controllers-k8s/community)
-[![Go Report Card](https://goreportcard.com/badge/github.com/aws-controllers-k8s/community)](https://goreportcard.com/report/github.com/aws-controllers-k8s/community)
 ![GitHub watchers](https://img.shields.io/github/watchers/aws-controllers-k8s/community?style=social)
 ![GitHub stars](https://img.shields.io/github/stars/aws-controllers-k8s/community?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/aws-controllers-k8s/community?style=social)
 
-
-
 # AWS Controllers for Kubernetes (ACK)
-**AWS Controllers for Kubernetes (ACK)** lets you define and use AWS service resources directly from Kubernetes. With ACK, you can take advantage of AWS managed services for your Kubernetes applications without needing to define resources outside of the cluster or run services that provide supporting capabilities like databases or message queues within the cluster.
 
-This is a new open source project built with ❤️ by AWS and available as a **Developer Preview**. We encourage you to [try it out](https://aws-controllers-k8s.github.io/community/dev-docs/testing/), provide feedback and contribute to development.
+**AWS Controllers for Kubernetes (ACK)** lets you define and use AWS service
+resources directly from Kubernetes. With ACK, you can take advantage of AWS
+managed services for your Kubernetes applications without needing to define
+resources outside of the cluster or run services that provide supporting
+capabilities like databases or message queues within the cluster.
 
-> **IMPORTANT** Because this project is in developer preview, you may see breaking changes throughout. We encourage you to experiment with ACK but DO NOT adopt it for production use. Use of ACK controllers in preview is subject to the terms and conditions contained in the [AWS Service Terms](https://aws.amazon.com/service-terms), particularly the Beta Service Participation Service Terms, and apply to any service controllers not marked as 'Generally Available'.
+ACK is an open source project built with ❤️  by AWS. The project is composed of
+many source code repositories containing a [common runtime][runtime-repo], a
+[code generator][codegen-repo] and Kubernetes custom controllers for individual
+AWS service APIs.
+
+[runtime-repo]: https://github.com/aws-controllers-k8s/runtime
+[codegen-repo]: https://github.com/aws-controllers-k8s/code-generator
+
+> **IMPORTANT** Please be sure to read our documentation about
+> [release versioning and maintenance phases][releases] and note that ACK
+> service controllers in the `Preview` maintenance phase are not recommended
+> for production use. Use of ACK controllers in `Preview` maintenance phase is
+> subject to the terms and conditions contained in the
+> [AWS Service Terms][aws-service-terms], particularly the Beta Service
+> Participation Service Terms, and apply to any service controllers in a
+> `Preview` maintenance phase.
+
+[releases]: https://aws-controllers-k8s.github.io/community/releases/
+[aws-service-terms]: https://aws.amazon.com/service-terms
 
 * [Overview](#overview)
 * [Getting Started](#getting-started)
@@ -26,15 +41,39 @@ This is a new open source project built with ❤️ by AWS and available as a **
 
 ## Overview
 
-Kubernetes applications often require a number of supporting resources like databases, message queues, and object stores. AWS provides a set of managed services that you can use to provide these resources for your apps, but provisioning and integrating them with Kubernetes was complex and time consuming. ACK lets you define and consume AWS services and resources directly from a Kubernetes cluster. It gives you a unified way to manage your application and its dependencies.
+Kubernetes applications often require a number of supporting resources like
+databases, message queues, and object stores. AWS provides a set of managed
+services that you can use to provide these resources for your apps, but
+provisioning and integrating them with Kubernetes was complex and time
+consuming. ACK lets you define and consume AWS services and resources directly
+from a Kubernetes cluster. It gives you a unified way to manage your
+application and its dependencies.
 
-ACK is a collection of Kubernetes [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs) and custom controllers working together to extend the Kubernetes API and manage AWS resources on your behalf.
+ACK is a collection of Kubernetes [custom resource definitions][crd] (CRDs) and
+custom controllers working together to extend the Kubernetes API and manage AWS
+resources on your behalf.
+
+[crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 
 ## Getting Started
 
-Until we've graduated ACK [service controllers](https://aws-controllers-k8s.github.io/community/services/) we ask you to [test-drive](https://aws-controllers-k8s.github.io/community/dev-docs/testing/) them.
+Currently, there are a set of ACK [service controllers][services] that have
+been released in a `Preview` [maintenance phase][maint-phases]. You may
+[install][install] these controllers in binary form using the Helm charts
+published on our ACK public artifact repository.
+
+[services]: https://aws-controllers-k8s.github.io/community/services/
+[maint-phases]: https://aws-controllers-k8s.github.io/community/releases#maintenance-phases
+[install]: https://aws-controllers-k8s.github.io/user-docs/install/
+
+If you are comfortable building Go code yourself and working with static
+Kubernetes manifests, you are also free to [test-drive][testing] various
+controllers using our KinD-based end-to-end test suite.
+
+[testing]: https://aws-controllers-k8s.github.io/community/dev-docs/testing/
 
 ## Help & Feedback
+
 For help, please consider the following venues (in order):
 
 * [ACK project documentation](https://aws-controllers-k8s.github.io/community/)
@@ -43,14 +82,18 @@ For help, please consider the following venues (in order):
 * Chat with us on the `#provider-aws` channel in the [Kubernetes Slack](https://kubernetes.slack.com/) community.
 
 ## Contributing
-We welcome community contributions and pull requests. See our [contribution guide](/CONTRIBUTING.md) for more information on how to report issues, set up a development environment, and submit code.
 
-Check the [issues list](https://github.com/aws-controllers-k8s/community/issues) for descriptions of work items. We invite any and all feedback and contributions, so please don't hesitate to submit an issue, a pull request or comment on an existing issue.
+We welcome community contributions and pull requests.
 
-ACK adheres to the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). You can also learn more about our [Governance](/GOVERNANCE.md) structure.
+See our [contribution guide](/CONTRIBUTING.md) for more information on how to
+report issues, set up a development environment, and submit code.
 
-## Use of Preview Service Controllers
-Use of ACK controllers in preview is subject to the terms and conditions contained in the AWS Service Terms, particularly the Beta Service Participation Service Terms, located at https://aws.amazon.com/service-terms, (the “Beta Terms”) and apply to any service controllers not marked as 'Generally Available'.
+We adhere to the [Amazon Open Source Code of Conduct][coc].
+
+You can also learn more about our [Governance](/GOVERNANCE.md) structure.
+
+[coc]: https://aws.github.io/code-of-conduct
 
 ## License
-This project is licensed under the Apache-2.0 License.
+
+This project is [licensed](/LICENSE) under the Apache-2.0 License.

--- a/docs/contents/releases.md
+++ b/docs/contents/releases.md
@@ -1,46 +1,52 @@
-# Releases
+# Releases, Versioning and Maintenance Phases
 
-We use the following different release statuses:
+Service controllers are built in separate source code repositories. Below, you
+will find a description of the [Project Stages](#project-stages) that a service
+controller repository goes through on its way to being released.
 
-* [PROPOSED](#proposed)
-* [PLANNED](#planned)
-* [BUILD](#build)
-* [DEVELOPER PREVIEW](#developer-preview)
-* [BETA](#beta)
-* [GENERALLY AVAILABLE](#generally-available) (GA)
+A controller that has reached the `RELEASED` project stage will have a set of
+release artifacts, including binary Docker images for the controller and a Helm
+Chart that installs the controller into a target Kubernetes cluster. Read more
+below about our [Releases and Versioning policy](#releases-and-versioning). 
 
-![ACK release criteria](images/release-criteria.png)
+Finally, we have a set of documented [Maintenance Phases](#maintenance-phases)
+that clearly outline our support stance for service controllers that have been
+released.
 
-## PROPOSED
+## Project Stages
 
-The `PROPOSEDD` status indicates that someone has expressed interest in
-supporting said service in ACK.
+The controller's "project stage" describes how far along the controller is
+towards being released:
 
-There will be a Github Issue for tracking the build of the ACK service
-controller for the service.
+[`PROPOSED`](#proposed) -> [`PLANNED`](#planned) -> [`IN PROGRESS`](#in-progress) -> [`RELEASED`](#released)
+
+### PROPOSED
+
+The `PROPOSED` stage indicates that there is expressed interest in supporting
+an AWS service in ACK.
+
+At this stage, there will be a Github Issue and/or a Github Project for
+tracking the creation of the ACK service controller for the service.
 
 The GitHub Issue **WILL NOT** be associated with a GitHub Milestone.
 
-## PLANNED
+### PLANNED
 
-The `PLANNED` status indicates that **the AWS service is on our radar** for
-building into ACK.
+The `PLANNED` stage indicates that we plan to make a controller for this
+service available in ACK.
 
-There will be a Github Issue for tracking the build of the ACK service
-controller for the service.
+At this stage, there **WILL BE** a GitHub Milestone that tracks progress
+towards the release of the controller.
 
-The GitHub Issue **WILL BE** associated with a GitHub Milestone indicating the
-target date for the `DEVELOPER PREVIEW` release of that service's controller.
+### IN PROGRESS
 
-## BUILD
+The `IN PROGRESS` stage indicates that the ACK service controller for the AWS
+service is **actively being built** in preparation for a release of that ACK
+service controller.
 
-The `BUILD` status indicates that the ACK service controller for the AWS
-service is **actively being built** in preparation for `DEVELOPER PREVIEW`
-release of that ACK service controller.
-
-It is in the `BUILD` status that we will identify those **AWS service API
-resources** that will be supported in `DEVELOPER PREVIEW` and which will be
-supported by the `GENERALLY AVAILABLE` release of the controller.
+In the `IN PROGRESS` stage we identify those **AWS service API resources** that
+will be supported by the controller and generate the code that manages the
+lifecycle of these resources.
 
 !!! note "what do we mean by 'AWS service API resources'?
     An *AWS service API resource* is a top-level object that can be created by
@@ -49,80 +55,246 @@ supported by the `GENERALLY AVAILABLE` release of the controller.
     Topic, PlatformApplication and PlatformEndpoint top-level resources that
     may be created.
 
-## DEVELOPER PREVIEW
+### RELEASED
 
-The `DEVELOPER PREVIEW` status indicates that the **source code and some
-documentation** for the ACK service controller for the AWS service has been
-check into the ACK source repository along with **minimual end-to-end test
-cases** that run against a local Kubernetes-in-Docker (KinD) cluster.
+The `RELEASED` project stage indicates that the ACK service controller source
+repository has had a Semantic Versioning Git tag applied and that both a Docker
+image and Helm Chart have been built and published to the ECR Public
+repositories for ACK.
 
-Notably, an ACK service controller in `DEVELOPER PREVIEW` **DOES NOT include
-Helm charts or published binary Docker images** for easy installation of the
-controller.
+Once a service controller reaches the `RELEASED` project stage, that **does not
+mean** that there can never be any changes or additions to the Custom Resource
+Definitions (CRDs) or public interfaces exposed by that service controller. The
+`RELEASED` project stage is simply an indication that there is at least one
+SemVer-tagged binary release of the controller.
 
-The following are release criteria for `DEVELOPER PREVIEW`:
+Consumers should look to the SemVer release tag as an indication of whether
+code included in that release introduces new breaking (major version increment)
+or non-breaking features (minor version increment) or simply bug fixes (patch
+version increment).  Consumers should see release notes for a release tag for a
+full description of changes included in that release.
 
-* Source code for the controller checked into ACK source repository
-* Mininal (smoke) tests for at least one service API resource
-* Documentation on to test the controller using KinD
+## Releases and Versioning
 
-The Custom Resource Definition (CRD) `APIVersion` for resources managed by ACK
-service controllers in `DEVELOPER PREVIEW` will carry an `alpha` designation --
-e.g. `v1alpha3`. Developers can expect major changes to the structure and
-format of the CRDs during the `DEVELOPER PREVIEW` release status.
+!!! important
+    ACK does *not* have a single release status or version.
+    Different components within the ACK project have different release cadences,
+    versions and statuses. Please read the information below before installing
+    any ACK component.
 
-## BETA
+Service controllers in ACK use [Semantic Versioning](#semantic-versioning) to
+indicate whether changes included in a particular binary release introduce
+features or bug fixes and whether or not features break backwards compatibility
+for public APIs and interfaces.
 
-The `BETA` status indicates that the ACK service controller for the AWS service
-**has Helm charts and published binary Docker images** that users can use to
-easily install and configure the controller.
+There are two release artifacts produced when an ACK service controller is
+released: a binary **Docker image** with the controller and a **Helm Chart**
+that installs the controller into a target Kubernetes cluster. Both these
+artifacts will have tags that correspond to the Semantic Version Git tag
+applied against the source code repository for the controller.
 
-In addition, ACK service controllers in `BETA` status have **more extensive
-end-to-end tests** included in the source repository and the successful running
-of these tests **gate any changes to the service controller source code**.
+Service controllers may have a [Stable Helm Chart](#stable-helm-charts) that
+will install a version of the service controller binary that the maintainer
+team is confident will hold up to production use.
 
-The following are release criteria for `BETA`:
+### Semantic Versioning
 
-* End-to-end tests of all CRUD operations for at least one service API resource
-* Documentation on how to install and configure the controller using Helm
-* All necessary artifacts such as container images and Helm charts are
-  available via a public container registry
+ACK is a collection of custom Kubernetes controllers, one for each supported
+AWS API. Each ACK controller is composed of an [ACK common runtime][ackrt] and
+Go code that links the Kubernetes API and the AWS API. Much of this Go code is
+generated by the [`ack-generate`][codegen] tool; some of the Go code is
+hand-crafted.
 
-The Custom Resource Definition (CRD) `APIVersion` for resources managed by ACK
-service controllers in `BETA` will carry an `beta` designation -- e.g.
-`v1beta1`. Developers can expect minor changes to the structure and format of
-the CRDs during the `BETA` release status, however **any change to the CRD
-format during the `BETA` release status will result in an incremented
-`APIVersion` for the CRD**. For example, consider a CRD with a
-`GroupVersionKind` (GVK) of `Bucket.s3.services.k8s.aws/v1beta2`. If the format
-of that CRD changed, we guarantee that a new `v1beta3` package and
-corresponding `Bucket.s3.services.k8s.aws/v1beta3` GVK would be released,
-allowing developers to cleanly migrate between API versions of their custom
-resources.
+[ackrt]: https://github.com/aws-controllers-k8s/runtime
+[codegen]: https://github.com/aws-controllers-k8s/code-generator
 
-## GENERALLY AVAILABLE
+**All code components** in ACK use [Semantic Versioning][semver] (SemVer) as a
+signal to consumers whether public interfaces or APIs have breaking changes.
 
-An ACK service controller reaches the `GENERALLY AVAILABLE` (GA) release status
-once a controller in the `BETA` release status has satisfied the following
-criteria:
+[semver]: https://semver.org/
 
-* End-to-end test coverage of all CRUD operations for all service API
-  resources for the specific service
-* Test coverage for "negative" or "fuzz" testing to ensure validating webhooks
-  properly guard the resource creation and mutation
-* Long-running "soak" testing to ensure controller reliability and stability
-* Documentation is included that demonstrates usage of the custom resources
-  managed by the controller
+When an ACK component is ***released***, a Git tag containing a SemVer (X.Y.Z)
+is created on the component's source repository. If the commits to the source
+repository in between the last Git tag and the commit being tagged have
+introduced changes that break public-facing APIs or interfaces, the SemVer will
+have its major version ("X") incremented. If the commits introduce
+functionality that does not break interfaces or APIs, the minor version ("Y")
+will be incremented. If the commits simply fix bugs and do not introduce any
+features or interface changes, the patch version ("Z") will be incremented.
 
-The Custom Resource Definition (CRD) `APIVersion` for resources managed by ACK
-service controllers in `GENERALLY AVAILABLE` will have a major version with no
-`alpha` or `beta` designation -- e.g.  `v1`. Developers can expect no changes
-to the structure and format of the CRDs once the controller is in the
-`GENERALLY AVAILABLE` release status.
+Releases of any ACK component that have a zero major release number (e.g.
+`v0.0.2`) may have breaking changes to the public API or interfaces exposed by
+that component.
 
-!!! note "How long from developer preview to GA?"
-    We aim to get an ACK service controller into the `GENERALLY AVAILABLE`
-    release status within 3 months of when the controller is released as
-    `DEVELOPER PREVIEW`. Some controllers will naturally take longer due to
-    inconsistencies, corner cases or complexity of the underlying AWS service
-    API.
+This is by design, and [per the Semantic Versioning specification][semver-zero]:
+
+> Major version zero (0.y.z) is for initial development. Anything MAY change at
+> any time. The public API SHOULD NOT be considered stable.
+
+[semver-zero]: https://semver.org/#spec-item-4
+
+For ACK components that have a binary distributable -- i.e. a Docker image --
+the creation of a new SemVer Git tag on the source code repository will trigger
+automatic building and publishing of a Docker image with an image tag including
+the SemVer version. For example, if a Git tag of `v1.2.6` was created on the
+[github.com/aws-controllers-k8s/s3-controller][s3-ctrl] repository, a Docker
+image with a tag `s3-v1.2.6` would be published to the
+[aws-controllers-k8s/controller][ecr-ack-ctrl] ECR repository.
+
+[s3-ctrl]: https://github.com/aws-controllers-k8s/s3-controller
+[ecr-ack-ctrl]: https://gallery.ecr.aws/aws-controllers-k8s/controller
+
+!!! note
+    Binaries for ACK components are published in our Amazon ECR
+    Public [registry][ecr-ack-ctrl].
+
+For ACK components that have a Helm Chart distributable -- i.e. an ACK service
+controller -- the creation of a new SemVer Git tag on the source code
+repository will trigger automatic building and publishing of a Helm Chart with
+an artifact tag including the SemVer version. For example, a Git tag of
+`v1.2.6` on the [github.com/aws-controllers-k8s/s3-controller][s3-ctrl]
+repository means a Helm chart with a tag `s3-v1.2.6` would be published to the
+[aws-controllers-k8s/chart][ecr-ack-chart] ECR repository.
+
+[ecr-ack-chart]: https://gallery.ecr.aws/aws-controllers-k8s/chart
+
+#### A Word About Dependencies
+
+Each service-specific ACK controller -- e.g. the ElastiCache ACK controller --
+depends on a specific version of the ACK common runtime. This dependency is
+specified in the controller's `go.mod` file.
+
+The ACK code generator that produces Go code for service controllers depends on
+a specific version of the ACK common runtime.
+
+!!! note "dependency between the code generator and common runtime"
+    The ACK code generator depends on the ACK common runtime in a unique way:
+    the Go code that the ACK code generator *produces* adheres to a specific
+    version of the ACK common runtime. Even though no Go code in the ACK code
+    generator actually imports the ACK common runtime, this dependency exists
+    because the Go code produced by the templates inside the code generator imports
+    the ACK common runtime. In order to make this Go code dependency more strict,
+    we have a test package inside the ACK code generator that imports the ACK
+    common runtime. In this way, we're able to include a version-specific
+    dependency line in the ACK code generator's `go.mod` file, thereby allowing
+    Go's module infrastructure to pin the dependency between the code generator and
+    the common runtime.
+
+### Stable Helm Charts
+
+!!! tip
+    We [recommend][recommend-helm] using Helm to install an ACK service
+    controller.
+
+[recommend-helm]: https://aws-controllers-k8s.github.io/community/user-docs/install/#helm-recommended
+
+Some ACK service controllers will have Helm Charts with a
+`$SERVICE-v$MAJOR_VERSION-stable` tag, referred from here out as just a
+"`stable` artifact tag". There will only be one of these tags for the ACK
+service controller **in a major version series**. For example, the `stable`
+artifact tag for the ElastiCache ACK service controller's "v1" major version
+series would be `elasticache-v1-stable`.
+
+This `stable` artifact tag points to a Helm chart that has configuration values
+that have been tested with a specific SemVer Docker image.
+Typically these tests are "soak" tests and allow the team maintaining that ACK
+controller's source code to have a high degree of confidence in the
+controller's long-running operation.
+
+!!! note
+    Please note that not all ACK service controllers will have a Helm chart
+    with a `stable` artifact tag. Furthermore, there will only ever be a single
+    `stable` Helm Chart tag **per major version series of a controller**.
+
+This `stable` Helm Chart tag (an OCI Artifact tag) will point to different
+Helm Chart packages over time. From time to time, the maintainer team for a
+service controller may update the configuration values and associated SemVer
+Docker image tag for the controller binary to point to a newer image.
+
+For example, consider the ElastiCache ACK service controller maintainer team
+has executed a series of long-running tests of the controller image tagged with
+the `elasticache-v1.2.6` SemVer tag. The maintainer team is confident that the
+controller is stable for production use. In the `stable` Git branch of the
+ElastiCache service controller's source repository, the team would update the
+Helm Chart's Deployment, setting the
+`Deployment.spec.template.spec.containers[0].image` to
+`public.ecr.aws/aws-controllers-k8s/controller/elasticache-v1.2.6`.
+
+They then package the Helm Chart and publish it as an OCI Artifact to the
+`public.ecr.aws/aws-controllers-k8s/chart` registry, using an OCI artifact tag
+of `elasticache-v1-stable`.
+
+A couple months later, the maintainer team has added a few minor, non-breaking
+features to their controller along with a number of bug fixes. The latest
+SemVer tag for the ElastiCache controller image is at `v1.3.9`.
+
+The maintainer team has separately been executing long-running tests against
+the `v1.3.2` controller image and are confident that this release is
+appropriate for production use. The maintainer team would update the Helm Chart
+in their `stable` Git branch to have its
+`Deployment.spec.template.spec.containers[0].image` set to
+`public.ecr.aws/aws-controllers-k8s/controller/elasticache-v1.3.2`. They would
+then package this Helm Chart and push overwrite the
+`public.ecr.aws/aws-controllers-k8s/chart:elasticache-v1-stable` OCI Artifact tag
+to point to this newly-updated Helm Chart that refers to the `v1.3.2`
+controller image.
+
+## Maintenance Phases
+
+As noted above, individual ACK service controllers all use Semantic Versioning
+("X.Y.Z") in order to signal breaking interface changes. However, each
+controller follows its own release cadence and each controller has a separate
+team of contributors that maintain the code, test the controller and determine
+whether the controller is stable in long-running operation.
+
+ACK service controllers having release tags within a major Semantic Version
+("X") will be in one of four Maintenance Phases:
+
+* [PREVIEW](#preview)
+* [GENERAL AVAILABILITY](#general-availability) (GA)
+* [DEPRECATED](#deprecated)
+* [NOT SUPPORTED](#not-supported)
+
+### Preview
+
+ACK controllers in the `Preview` Maintenance Phase are released for testing by
+users and are not recommended for production use.
+
+For `Preview` controllers, we ask users to submit bug reports using Github
+Issues and we will do our best to remediate problems in a timely manner.
+
+### General Availability
+
+ACK controllers in the `General Availability` (GA) Maintenance Phase have been
+through long-running "soak" tests and are recommended for production use by the
+team maintaining that controller.
+
+All ACK controllers in the `General Availability` Maintenance Phase will have a
+Helm Chart with the `stable` artifact tag.
+
+Users who submit bug reports using Github Issues that reference a `General
+Availability` controller will have their bug reports prioritized by the
+contributor team maintaining that controller.
+
+### Deprecated
+
+ACK controllers in the `General Availability` Maintenance Phase may move to a
+`Deprecated` Maintenance Phase after a Deprecation Warning notice has been sent
+out (and the controller's documentation has been updated with said deprecation
+notice).
+
+Controllers in `Deprecated` Maintenance Phase continue to receive the same
+level of support as controllers in the `General Availability` phase.
+
+### Not Supported
+
+ACK controllers may eventually be moved into a `Not Supported` Maintenance Phase.
+
+A controller major version series may move from the `Preview` Maintenance Phase
+to the `Not Supported` Maintenance Phase at any time. This may happen if the
+team maintaining the controller determines it is not possible to get the
+controller with that major version series into a `General Availability` phase.
+
+A controller major version series may move from the `Deprecated`
+Maintenance Phase to the `Not Supported` Maintenance Phase *only after a 1-year
+deprecation period has elapsed*.

--- a/docs/contents/services.md
+++ b/docs/contents/services.md
@@ -1,204 +1,223 @@
 # Services
 
 The following AWS service APIs have service controllers included in ACK or have
-controllers currently being built.
+controllers in one of our [several project stages][project-stages].
+
+[project-stages]: https://aws-controllers-k8s.github.io/community/releases#project-stages
+
+ACK controllers that have reached the `RELEASED` project stage will also be in
+one of our [maintenance phases][maint-phases].
+
+[maint-phases]: https://aws-controllers-k8s.github.io/community/releases#maintenance-phases
 
 For details, including a list of planned AWS service APIs, see the [Service
-Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/1):
+Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/projects/1):
 
 !!! note "IMPORTANT"
     There is no single release of the ACK project. The ACK project contains a
     series of service controllers, one for each AWS service API. Each
     individual ACK service controller is released separately. Please see the
-    documentation on [release criteria](releases.md) for information on how we
+    [release documentation][releases] for information on how we version and
     release ACK service controllers.
 
-| AWS Service | Current Status | Next Milestone
+[releases]: https://aws-controllers-k8s.github.io/community/releases
+
+| AWS Service | Project Stage | Maintenance Phase | Next Milestone
 | ----------- | -------------- | --------------
-| Amazon [ACM](#amazon-acm) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/482) |
-| Amazon [API Gateway V2](#amazon-api-gateway-v2) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/207) | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/15)
-| Amazon [CloudFront Distribution](#amazon-cloudfront-distribution) | [`PLANNED`](https://github.com/aws/aws-controllers-k8s/issues/249) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/14)
-| Amazon [DynamoDB](#amazon-dynamodb) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/2060) |
-| Amazon [ECR](#amazon-ecr) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/208) |
-| Amazon [EFS](#amazon-efs) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/328) |
-| Amazon [EKS](#amazon-eks) | [`PLANNED`](https://github.com/aws/aws-controllers-k8s/issues/16) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/7)
-| Amazon [ElastiCache](#amazon-elasticache) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/240) | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/9)
-| Amazon [Elasticsearch](#amazon-elasticsearch) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/503) |
-| Amazon [EC2 VPC](#amazon-ec2-vpc) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/489) |
-| AWS [IAM](#aws-iam) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/222) |
-| AWS [Lambda](#aws-lambda) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/238) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/10)
-| AWS [Kinesis](#aws-kinesis) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/235) |
-| Amazon [KMS](#amazon-kms) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/491) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/18)
-| Amazon [MQ](#amazon-mq) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/390) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/12)
-| Amazon [MSK](#amazon-msk) | [`PLANNED`](https://github.com/aws/aws-controllers-k8s/issues/348) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/13)
-| Amazon [RDS](#amazon-rds) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/237) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/8)
-| Amazon [Route53](#amazon-route53) | [`PROPOSED`](https://github.com/aws/aws-controllers-k8s/issues/480) |
-| Amazon [SageMaker](#amazon-sagemaker) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/385) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/11)
-| Amazon [SNS](#amazon-sns) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/202) |
-| Amazon [SQS](#amazon-sqs) | [`BUILD`](https://github.com/aws/aws-controllers-k8s/issues/205) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/6)
-| AWS [Step Functions](#aws-step-functions) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/239) |
-| Amazon [S3](#amazon-s3) | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/issues/204) |
+| Amazon [ACM](#amazon-acm) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/482) | |
+| Amazon [API Gateway V2](#amazon-api-gateway-v2) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/207) | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/15
+| Amazon [CloudFront Distribution](#amazon-cloudfront-distribution) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/249) | | https://github.com/aws-controllers-k8s/community/milestone/14
+| Amazon [DynamoDB](#amazon-dynamodb) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/2060) | `PREVIEW` |
+| Amazon [ECR](#amazon-ecr) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/208) | `PREVIEW` |
+| Amazon [EFS](#amazon-efs) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/328) | |
+| Amazon [EKS](#amazon-eks) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/16) | | https://github.com/aws-controllers-k8s/community/milestone/7
+| Amazon [ElastiCache](#amazon-elasticache) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/240) | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/9
+| Amazon [Elasticsearch](#amazon-elasticsearch) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/503) | |
+| Amazon [EC2 VPC](#amazon-ec2-vpc) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/489) | |
+| AWS [IAM](#aws-iam) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/222) | |
+| AWS [Lambda](#aws-lambda) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/238) | | https://github.com/aws-controllers-k8s/community/milestone/10
+| AWS [Kinesis](#aws-kinesis) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/235) | |
+| Amazon [KMS](#amazon-kms) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/491) | | https://github.com/aws-controllers-k8s/community/milestone/18
+| Amazon [MQ](#amazon-mq) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/390) | | https://github.com/aws-controllers-k8s/community/milestone/12
+| Amazon [MSK](#amazon-msk) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/348) | | https://github.com/aws-controllers-k8s/community/milestone/13
+| Amazon [RDS](#amazon-rds) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/237) | | https://github.com/aws-controllers-k8s/community/milestone/8
+| Amazon [Route53](#amazon-route53) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/480) | |
+| Amazon [SageMaker](#amazon-sagemaker) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/385) | | https://github.com/aws-controllers-k8s/community/milestone/11
+| Amazon [SNS](#amazon-sns) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/202) | `PREVIEW` |
+| Amazon [SQS](#amazon-sqs) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/205) | | https://github.com/aws-controllers-k8s/community/milestone/6
+| AWS [Step Functions](#aws-step-functions) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/239) | `PREVIEW` |
+| Amazon [S3](#amazon-s3) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/204) | `PREVIEW` |
 
 !!! note "Don't see a service listed?"
     If you don't see a particular AWS service listed, feel free to
-    [propose it](https://github.com/aws/aws-controllers-k8s/issues/new?labels=Service+Controller&template=propose_new_controller.md&title=%5Bname%5D+service+controller)!
+    [propose it](https://github.com/aws-controllers-k8s/community/issues/new?labels=Service+Controller&template=propose_new_controller.md&title=%5Bname%5D+service+controller)!
 
 ## Amazon ACM
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/482
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/482
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/acm/
 
 ## Amazon API Gateway v2
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/207
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/15)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/207
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/15
 * AWS service documentation: https://aws.amazon.com/api-gateway/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/apigatewayv2
+* ACK service controller: https://github.com/aws-controllers-k8s/apigatewayv2-controller
 
 ## Amazon CloudFront Distribution
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/249
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/14)
-* Current release status: `PLANNED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/249
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/14
+* Current project stage: `PLANNED`
 * AWS service documentation: https://aws.amazon.com/cloudfront/
 
 ## Amazon DynamoDB
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/206
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/16)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/206
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/dynamodb/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/dynamodb
+* ACK service controller: https://github.com/aws-controllers-k8s/dynamodb-controller
 
 ## Amazon ECR
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/208
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/16)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/208
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/ecr/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/ecr
+* ACK service controller: https://github.com/aws-controllers-k8s/ecr-controller
 
 ## Amazon EFS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/328
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/328
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/efs/
 
 ## Amazon EKS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/16
-* Current release status: `PLANNED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/16
+* Current project stage: `PLANNED`
 * AWS service documentation: https://aws.amazon.com/eks/
 
 ## Amazon ElastiCache
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/240
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/9)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/240
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/9
 * AWS service documentation: https://aws.amazon.com/elasticache/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/elasticache
+* ACK service controller: https://github.com/aws-controllers-k8s/elasticache-controller
 
 ## Amazon Elasticsearch
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/503
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/503
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/elasticsearch-service/
 
 ## Amazon EC2 VPC
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/489
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/489
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://docs.aws.amazon.com/vpc/
 
 ## AWS IAM
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/222
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/222
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/iam/
 
 ## AWS Lambda
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/238
-* Current release status: `BUILD`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/10)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/238
+* Current project stage: `IN PROGRESS`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/10
 * AWS service documentation: https://aws.amazon.com/lambda/
 
 ## Amazon Kinesis
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/235
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/235
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/kinesis/
 
 ## AWS KMS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/491
-* Current release status: `BUILD`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/18)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/491
+* Current project stage: `IN PROGRESS`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/18
 * AWS service documentation: https://aws.amazon.com/kms/
+* ACK service controller: https://github.com/aws-controllers-k8s/kms-controller
 
 ## Amazon MQ
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/390
-* Current release status: `BUILD`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/12)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/390
+* Current project stage: `IN PROGRESS`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/12
 * AWS service documentation: https://aws.amazon.com/amazon-mq/
+* ACK service controller: https://github.com/aws-controllers-k8s/mq-controller
 
 ## Amazon MSK
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/348
-* Current release status: `PLANNED`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/13)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/348
+* Current project stage: `PLANNED`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/13
 * AWS service documentation: https://aws.amazon.com/msk/
 
 ## Amazon RDS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/237
-* Current release status: `PLANNED`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/8)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/237
+* Current project stage: `PLANNED`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/8
 * AWS service documentation: https://aws.amazon.com/rds/
 
 ## Amazon Route53
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/480
-* Current release status: `PROPOSED`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/480
+* Current project stage: `PROPOSED`
 * AWS service documentation: https://docs.aws.amazon.com/Route53/
 
 ## Amazon SageMaker
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/385
-* Current release status: `BUILD`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/11)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/385
+* Current project stage: `IN PROGRESS`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/11
 * AWS service documentation: https://aws.amazon.com/sagemaker/
+* ACK service controller: https://github.com/aws-controllers-k8s/sagemaker-controller
 
 ## Amazon SNS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/202
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/17)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/202
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/17
 * AWS service documentation: https://aws.amazon.com/sns/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sns
+* ACK service controller: https://github.com/aws-controllers-k8s/sns-controller
 
 ## Amazon SQS
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/205
-* Current release status: `BUILD`
-* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/6)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/205
+* Current project stage: `IN PROGRESS`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/6
 * AWS service documentation: https://aws.amazon.com/sqs/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sqs
+* ACK service controller: https://github.com/aws-controllers-k8s/sqs-controller
 
 ## AWS Step Functions
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/239
-* Current release status: `DEVELOPER PREVIEW`
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/239
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
 * AWS service documentation: https://aws.amazon.com/step-functions/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sfn
+* ACK service controller: https://github.com/aws-controllers-k8s/sfn-controller
 
 ## Amazon S3
 
-* Proposed: https://github.com/aws/aws-controllers-k8s/issues/204
-* Current release status: `DEVELOPER PREVIEW`
-* Next milestone: [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/16)
+* Proposed: https://github.com/aws-controllers-k8s/community/issues/204
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
+* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/s3/
-* ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/s3
+* ACK service controller: https://github.com/aws-controllers-k8s/s3-controller


### PR DESCRIPTION
Our existing single "release status" was too coarse and was leading to
confusion -- both from customers as well as internal service teams --
about supportability and maintenance policy for controllers in the
different release statuses.

This patch updates our documentation to clarify what we mean by a
"release" and a "version". It also describes two separate concepts:
the **project stage** and the **maintenance phase**.

The controller's "project stage" describes how far along the controller
is towards being released:

`PROPOSED` -> `PLANNED` -> `BUILD` -> `RELEASED`

There's nothing about our support stance or what percentage of an API's
resources need to be implemented or what test coverage is the bar to
reach. Instead, the `RELEASED` project stage is reached when a SemVer Git
tag is applied to the source code repository and Docker images and Helm
Charts are automatically built and published to our ECR Public repo.

Secondly, there is the concept of a "maintenance phase", which describes
our support stance and the maintaining team's confidence that the
controller is ready for production use and has been tested in
long-running operational tests.

There are four maintenance phases. A maintenance phase describes a
**major SemVer version series** of a controller in the `RELEASED` build
stage:

`PREVIEW` describes a controller major version series that is not yet
recommended for production use by the maintainer team.

`GENERALLY AVAILABLE` describes a controller major version series that
is recommended for production use by the maintainer team.

`DEPRECATED` describes a controller major version series that will no
longer be supported in the future.

`NOT SUPPORTED` describes a controller major version series that is no
longer maintained. A controller major version series can go from
`PREVIEW` directly to `NOT SUPPORTED`. However, a controller major
version series in `GENERALLY AVAILABLE` maintenance phase must go into
the `DEPRECATED` maintenance phase for one year before being moved to
`NOT SUPPORTED` maintenance phase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
