### PR TITLE
Fix errors while build controller release

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -8,7 +8,6 @@ set -eo pipefail
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
-TEMPLATES_DIR="$ROOT_DIR/templates"
 DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
 
 source "$SCRIPTS_DIR/lib/common.sh"
@@ -128,7 +127,7 @@ helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
 # not affect the release artifacts produced from `ack-generate release`.
 # TODO(jaypipes): Clean this up so the `ack-generate release` command
 # doesn't need to look up a go.mod file for aws-sdk-go version.
-ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-go-version 1.35.5"
+ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-go-version v1.35.5"
 if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
     ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
 fi


### PR DESCRIPTION

Issue #, if available:

- `--aws-sdk-go-version` argument value needed to be a valid tag value ('v' prefix)
- Incorrect template directory was referred when
  `./scripts/build-controller-release.sh $SERVICE $RELEASE_VERSION;`
  is invoked.

Description of changes:

Updated `build-controller-release.sh` script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
