### PR TITLE
Specify image tag during 'Publish the controller images' release step

### DIFF
--- a/docs/contents/dev-docs/release.md
+++ b/docs/contents/dev-docs/release.md
@@ -119,8 +119,9 @@ controller images:
 
 ```bash
 export DOCKER_REPOSITORY=public.ecr.aws/aws-controllers-k8s/controller
-for SERVICE in s3 sns; 
-    do ./scripts/publish-controller-image.sh $SERVICE
+for SERVICE in s3 sns; do
+    export AWS_SERVICE_DOCKER_IMG=$DOCKER_REPOSITORY:$SERVICE-$RELEASE_VERSION
+    ./scripts/publish-controller-image.sh $SERVICE
 done
 ```
 


### PR DESCRIPTION
Issue #, if available:

While following the `release.md` steps the `publish-controller-image.sh` script needs to be invoked with `AWS_SERVICE_DOCKER_IMG` environment variable set to expected value. Else, incorrect value (like `public.ecr.aws/aws-controllers-k8s/controller:elasticache-v0.0.2-38-g7e23fa3-dirty`) is used as default.

Note: the tag `v0.0.2` and `38` commits and commit `g7e23fa3` refers to `community` repository and not the expected `elasticache-controller` repository. The `publish-controller-image.sh` needs fix for this default value. 
* Created issue #693 for it.

During release steps, the default behavior is not correct; thus, there is a need to specify `AWS_SERVICE_DOCKER_IMG` environment variable.

Description of changes:

* Updated `release.md` file to specify image tag during 'Publish the controller images' release step.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
