### PR TITLE
Elasticache: setup python test framework, add replication group input coverage tests

### DIFF
--- a/test/e2e/elasticache/__init__.py
+++ b/test/e2e/elasticache/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+SERVICE_NAME = "elasticache"
+CRD_GROUP = "elasticache.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+# PyTest marker for the current service
+service_marker = pytest.mark.service(arg=SERVICE_NAME)

--- a/test/e2e/elasticache/resources/replicationgroup_cmd_fromsnapshot.yaml
+++ b/test/e2e/elasticache/resources/replicationgroup_cmd_fromsnapshot.yaml
@@ -1,0 +1,13 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+  replicationGroupDescription: test replication group for input field coverage
+  replicationGroupID: $RG_ID
+  snapshotName: $SNAPSHOT_NAME
+  numCacheClusters: 3
+  preferredCacheClusterAZs:
+    - us-east-1a
+    - us-east-1b
+    - us-east-1c

--- a/test/e2e/elasticache/resources/replicationgroup_input_coverage.yaml
+++ b/test/e2e/elasticache/resources/replicationgroup_input_coverage.yaml
@@ -1,0 +1,49 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+  atRestEncryptionEnabled: true
+  authToken: testplaintexttoken
+  autoMinorVersionUpgrade: true
+  automaticFailoverEnabled: true
+  cacheNodeType: cache.t3.small
+  cacheParameterGroupName: default.redis6.x.cluster.on
+  cacheSubnetGroupName: default
+  engine: redis
+  engineVersion: 6.x
+  kmsKeyID: $KMS_KEY_ID
+  multiAZEnabled: true
+  nodeGroupConfiguration:
+    - nodeGroupID: "1111"
+      primaryAvailabilityZone: us-east-1a
+      replicaAvailabilityZones:
+        - us-east-1b
+      replicaCount: 1
+      slots: 0-5999
+    - nodeGroupID: "2222"
+      primaryAvailabilityZone: us-east-1c
+      replicaAvailabilityZones:
+        - us-east-1d
+        - us-east-1a
+        - us-east-1b
+      replicaCount: 3
+      slots: 6000-16383
+  notificationTopicARN: $SNS_TOPIC_ARN
+  numNodeGroups: 2
+  port: 6380
+  preferredMaintenanceWindow: sun:23:00-mon:01:30
+  replicationGroupDescription: test replication group for input field coverage
+  replicationGroupID: $RG_ID
+  securityGroupIDs:
+    - $SG_ID
+  snapshotRetentionLimit: 5
+  snapshotWindow: 05:00-06:00
+  tags:
+    - key: service
+      value: elasticache
+    - key: region
+      value: us-east-1
+  transitEncryptionEnabled: true
+  userGroupIDs:
+    - $USERGROUP_ID

--- a/test/e2e/elasticache/service_bootstrap.py
+++ b/test/e2e/elasticache/service_bootstrap.py
@@ -1,0 +1,113 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Bootstraps the resources required to run Elasticache integration tests.
+"""
+
+import boto3
+import logging
+
+from common.aws import get_aws_account_id, get_aws_region
+from common.resources import random_suffix_name
+from dataclasses import dataclass
+from elasticache.util import wait_usergroup_active, wait_snapshot_available
+
+def create_sns_topic() -> str:
+    topic_name = random_suffix_name("ack-sns-topic", 32)
+
+    sns = boto3.client("sns")
+    response = sns.create_topic(Name=topic_name)
+    logging.info(f"Created SNS topic {response['TopicArn']}")
+
+    return response['TopicArn']
+
+# create an EC2 VPC security group from the default VPC (not an ElastiCache security group)
+def create_security_group() -> str:
+    region = get_aws_region()
+    account_id = get_aws_account_id()
+
+    ec2 = boto3.client("ec2")
+    vpc_response = ec2.describe_vpcs(Filters=[{"Name": "isDefault", "Values": ["true"]}])
+    if len(vpc_response['Vpcs']) == 0:
+        raise ValueError(f"Default VPC not found for account {account_id} in region {region}")
+    default_vpc_id = vpc_response['Vpcs'][0]['VpcId']
+
+    sg_name = random_suffix_name("ack-security-group", 32)
+    sg_description = "Security group for ACK ElastiCache tests"
+    sg_response = ec2.create_security_group(GroupName=sg_name, VpcId=default_vpc_id, Description=sg_description)
+    logging.info(f"Created VPC Security Group {sg_response['GroupId']}")
+
+    return sg_response['GroupId']
+
+def create_user_group() -> str:
+    ec = boto3.client("elasticache")
+
+    usergroup_id = random_suffix_name("ack-ec-usergroup", 32)
+    _ = ec.create_user_group(UserGroupId=usergroup_id,
+                                    Engine="Redis",
+                                    UserIds=["default"])
+    logging.info(f"Creating ElastiCache User Group {usergroup_id}")
+    assert wait_usergroup_active(usergroup_id)
+
+    return usergroup_id
+
+def create_kms_key() -> str:
+    kms = boto3.client("kms")
+
+    response = kms.create_key(Description="Key for ACK ElastiCache tests")
+    key_id = response['KeyMetadata']['KeyId']
+    logging.info(f"Created KMS key {key_id}")
+
+    return key_id
+
+# create a cache cluster, snapshot it, and return the snapshot name
+def create_cc_snapshot():
+    ec = boto3.client("elasticache")
+
+    cc_id = random_suffix_name("ack-cache-cluster", 32)
+    _ = ec.create_cache_cluster(
+        CacheClusterId=cc_id,
+        NumCacheNodes=1,
+        CacheNodeType="cache.m6g.large",
+        Engine="redis"
+    )
+    waiter = ec.get_waiter('cache_cluster_available')
+    waiter.wait(CacheClusterId=cc_id)
+    logging.info(f"Created cache cluster {cc_id} for snapshotting")
+
+    snapshot_name = random_suffix_name("ack-cc-snapshot", 32)
+    _ = ec.create_snapshot(
+        CacheClusterId=cc_id,
+        SnapshotName=snapshot_name
+    )
+    assert wait_snapshot_available(snapshot_name)
+
+    return snapshot_name
+
+@dataclass
+class BootstrapResources:
+    SnsTopicARN: str
+    SecurityGroupID: str
+    UserGroupID: str
+    KmsKeyID: str
+    SnapshotName: str
+
+def service_bootstrap() -> dict:
+    logging.getLogger().setLevel(logging.INFO)
+
+    return BootstrapResources(
+        create_sns_topic(),
+        create_security_group(),
+        create_user_group(),
+        create_kms_key(),
+        create_cc_snapshot()
+    ).__dict__

--- a/test/e2e/elasticache/service_cleanup.py
+++ b/test/e2e/elasticache/service_cleanup.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Cleans up the resources created by the Elasticache bootstrapping process.
+"""
+
+import boto3
+import logging
+
+from elasticache.service_bootstrap import BootstrapResources
+
+def delete_sns_topic(topic_ARN: str):
+    sns = boto3.client("sns")
+    sns.delete_topic(TopicArn=topic_ARN)
+    logging.info(f"Deleted SNS topic {topic_ARN}")
+
+def delete_security_group(sg_id: str):
+    ec2 = boto3.client("ec2")
+    ec2.delete_security_group(GroupId=sg_id)
+    logging.info(f"Deleted VPC Security Group {sg_id}")
+
+def delete_user_group(usergroup_id: str):
+    ec = boto3.client("elasticache")
+    ec.delete_user_group(UserGroupId=usergroup_id)
+    logging.info(f"Deleted ElastiCache User Group {usergroup_id}")
+
+# KMS does not allow immediate key deletion; 7 days is the shortest deletion window
+def delete_kms_key(key_id: str):
+    kms = boto3.client("kms")
+    kms.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
+    logging.info(f"Deletion scheduled for KMS key {key_id}")
+
+# delete snapshot and also associated cluster/RG
+def delete_snapshot(snapshot_name: str):
+    ec = boto3.client("elasticache")
+
+    # delete actual snapshot
+    response = ec.describe_snapshots(SnapshotName=snapshot_name)
+    snapshot = response['Snapshots'][0]
+    ec.delete_snapshot(SnapshotName=snapshot_name)
+    logging.info(f"Deleted snapshot {snapshot_name}")
+
+    # delete resource that was used to create snapshot
+    if snapshot['CacheClusterId']:
+        ec.delete_cache_cluster(CacheClusterId=snapshot['CacheClusterId'])
+        logging.info(f"Deleted cache cluster {snapshot['CacheClusterId']}")
+    elif snapshot['ReplicationGroupId']: # should not happen
+        ec.delete_replication_group(ReplicationGroupId=snapshot['ReplicationGroupId'])
+        logging.info(f"Deleted replication group {snapshot['ReplicationGroupId']}")
+
+def service_cleanup(config: dict):
+    logging.getLogger().setLevel(logging.INFO)
+
+    resources = BootstrapResources(
+        **config
+    )
+
+    try:
+        delete_sns_topic(resources.SnsTopicARN)
+    except:
+        logging.exception(f"Unable to delete SNS topic {resources.SnsTopicARN}")
+
+    try:
+        delete_security_group(resources.SecurityGroupID)
+    except:
+        logging.exception(f"Unable to delete VPC Security Group {resources.SecurityGroupID}")
+
+    try:
+        delete_user_group(resources.UserGroupID)
+    except:
+        logging.exception(f"Unable to delete ElastiCache User Group {resources.UserGroupID}")
+
+    try:
+        delete_kms_key(resources.KmsKeyID)
+    except:
+        logging.exception(f"Unable to schedule deletion for KMS key {resources.KmsKeyID}")
+
+    try:
+        delete_snapshot(resources.SnapshotName)
+    except:
+        logging.exception(f"Unable to delete snapshot {resources.SnapshotName}")

--- a/test/e2e/elasticache/tests/__init__.py
+++ b/test/e2e/elasticache/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/e2e/elasticache/tests/test_replicationgroup.py
+++ b/test/e2e/elasticache/tests/test_replicationgroup.py
@@ -1,0 +1,108 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the Elasticache ReplicationGroup resource
+"""
+
+import pytest
+import boto3
+import logging
+
+from common.resources import read_bootstrap_config, random_suffix_name, load_resource_file
+from common import k8s
+from time import sleep
+from elasticache import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from elasticache.service_bootstrap import BootstrapResources
+
+RESOURCE_PLURAL = "replicationgroups"
+DEFAULT_WAIT_SECS = 30
+
+@pytest.fixture(scope="module")
+def rg_deletion_waiter():
+    ec = boto3.client("elasticache")
+    return ec.get_waiter('replication_group_deleted')
+
+# retrieve resources created in the bootstrap step
+@pytest.fixture(scope="module")
+def bootstrap_resources():
+    return BootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+
+# factory for replication group names
+@pytest.fixture(scope="module")
+def make_rg_name():
+    def _make_rg_name(base):
+        return random_suffix_name(base, 32)
+
+    return _make_rg_name
+
+# factory for replication groups
+@pytest.fixture(scope="module")
+def make_replication_group():
+    def _make_replication_group(yaml_name, input_dict, rg_name):
+        rg = load_resource_file(
+            SERVICE_NAME, yaml_name, additional_replacements=input_dict)
+        logging.debug(rg)
+
+        reference = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, rg_name, namespace="default")
+        _ = k8s.create_custom_resource(reference, rg)
+        resource = k8s.wait_resource_consumed_by_controller(reference, wait_periods=10)
+        assert resource is not None
+        return (reference, resource)
+
+    return _make_replication_group
+
+@pytest.fixture(scope="module")
+def rg_input_coverage(bootstrap_resources, make_rg_name, make_replication_group, rg_deletion_waiter):
+    input_dict = {
+        "RG_ID": make_rg_name("rg-input-coverage"),
+        "KMS_KEY_ID": bootstrap_resources.KmsKeyID,
+        "SNS_TOPIC_ARN": bootstrap_resources.SnsTopicARN,
+        "SG_ID": bootstrap_resources.SecurityGroupID,
+        "USERGROUP_ID": bootstrap_resources.UserGroupID
+    }
+
+    (reference, resource) = make_replication_group("replicationgroup_input_coverage", input_dict, input_dict["RG_ID"])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"]) #throws exception if wait fails
+
+@pytest.fixture(scope="module")
+def rg_cmd_fromsnapshot(bootstrap_resources, make_rg_name, make_replication_group, rg_deletion_waiter):
+    input_dict = {
+        "RG_ID": make_rg_name("rg-cmd-fromsnapshot"),
+        "SNAPSHOT_NAME": bootstrap_resources.SnapshotName
+    }
+
+    (reference, resource) = make_replication_group("replicationgroup_cmd_fromsnapshot", input_dict, input_dict["RG_ID"])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"])
+
+
+@service_marker
+class TestReplicationGroup:
+
+    def test_rg_input_coverage(self, rg_input_coverage):
+        (reference, _) = rg_input_coverage
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+    def test_rg_cmd_fromsnapshot(self, rg_cmd_fromsnapshot):
+        (reference, _) = rg_cmd_fromsnapshot
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)

--- a/test/e2e/elasticache/util.py
+++ b/test/e2e/elasticache/util.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""ElastiCache-specific test utility functions
+"""
+
+import logging
+import boto3
+
+from time import sleep
+
+def wait_usergroup_active(usergroup_id: str,
+                           wait_periods: int = 10,
+                           period_length: int = 60) -> bool:
+    ec = boto3.client("elasticache")
+    for i in range(wait_periods):
+        logging.debug(f"Waiting for user group {usergroup_id} to be active ({i})")
+        response = ec.describe_user_groups(UserGroupId=usergroup_id)
+        user_group = response['UserGroups'][0]
+
+        if not user_group:
+            logging.error(f"Could not find User Group {usergroup_id}")
+            return False
+
+        if user_group['Status'] == "active":
+            logging.info(f"User Group {usergroup_id} is active, continuing...")
+            return True
+
+        sleep(period_length)
+
+    logging.error(f"Wait for User Group {usergroup_id} to be active timed out")
+    return False
+
+def wait_snapshot_available(snapshot_name: str,
+                            wait_periods: int = 10,
+                            period_length: int = 60) -> bool:
+    ec = boto3.client("elasticache")
+    for i in range(wait_periods):
+        logging.debug(f"Waiting for snapshot {snapshot_name} to be available ({i})")
+        response = ec.describe_snapshots(SnapshotName=snapshot_name)
+        snapshot = response['Snapshots'][0]
+
+        if not snapshot:
+            logging.error(f"Could not find snapshot {snapshot_name}")
+            return False
+
+        if snapshot['SnapshotStatus'] == "available":
+            logging.info(f"Snapshot {snapshot_name} is available, continuing...")
+            return True
+
+        sleep(period_length)
+
+    logging.error(f"Wait for snapshot {snapshot_name} to be available timed out")
+    return False


### PR DESCRIPTION
Add tests (and associated setup/teardown) to cover most fields in the replication group create input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
