### PR TITLE
integ tests: sagemaker endpoint config and endpoint

### DIFF
--- a/test/e2e/sagemaker/__init__.py
+++ b/test/e2e/sagemaker/__init__.py
@@ -17,5 +17,9 @@ SERVICE_NAME = "sagemaker"
 CRD_GROUP = "sagemaker.services.k8s.aws"
 CRD_VERSION = "v1alpha1"
 
+CONFIG_RESOURCE_PLURAL = 'endpointconfigs'
+MODEL_RESOURCE_PLURAL = 'models'
+ENDPOINT_RESOURCE_PLURAL = 'endpoints'
+
 # PyTest marker for the current service
 service_marker = pytest.mark.service(arg=SERVICE_NAME)

--- a/test/e2e/sagemaker/resources/endpoint_base.yaml
+++ b/test/e2e/sagemaker/resources/endpoint_base.yaml
@@ -1,0 +1,7 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Endpoint
+metadata:
+  name: $ENDPOINT_NAME
+spec:
+  endpointName: $ENDPOINT_NAME
+  endpointConfigName: $CONFIG_NAME

--- a/test/e2e/sagemaker/resources/endpoint_config_single_variant.yaml
+++ b/test/e2e/sagemaker/resources/endpoint_config_single_variant.yaml
@@ -1,0 +1,16 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: EndpointConfig
+metadata:
+  name: $CONFIG_NAME
+spec:
+  endpointConfigName: $CONFIG_NAME
+  productionVariants:
+    - variantName: variant-1
+      modelName: $MODEL_NAME
+      initialInstanceCount: 1
+      # This is the smallest instance type which will support scaling
+      instanceType: ml.c5.large
+      initialVariantWeight: 1
+  tags:
+    - key: var
+      value: val

--- a/test/e2e/sagemaker/tests/__init__.py
+++ b/test/e2e/sagemaker/tests/__init__.py
@@ -4,7 +4,7 @@
 # not use this file except in compliance with the License. A copy of the
 # License is located at
 #
-#	 http://aws.amazon.com/apache2.0/
+# 	 http://aws.amazon.com/apache2.0/
 #
 # or in the "license" file accompanying this file. This file is distributed
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/test/e2e/sagemaker/tests/test_endpoint.py
+++ b/test/e2e/sagemaker/tests/test_endpoint.py
@@ -1,0 +1,262 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the SageMaker Endpoint API.
+"""
+
+import boto3
+import pytest
+import logging
+import time
+from typing import Dict
+
+from sagemaker import (
+    SERVICE_NAME,
+    service_marker,
+    CRD_GROUP,
+    CRD_VERSION,
+    CONFIG_RESOURCE_PLURAL,
+    MODEL_RESOURCE_PLURAL,
+    ENDPOINT_RESOURCE_PLURAL,
+)
+from sagemaker.replacement_values import REPLACEMENT_VALUES
+from common.resources import load_resource_file, random_suffix_name
+from common import k8s
+
+
+@pytest.fixture(scope="module")
+def sagemaker_client():
+    return boto3.client("sagemaker")
+
+
+@pytest.fixture(scope="module")
+def single_variant_xgboost_endpoint():
+    endpoint_resource_name = random_suffix_name("single-variant-endpoint", 32)
+    config1_resource_name = endpoint_resource_name + "-config"
+    model_resource_name = config1_resource_name + "-model"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["ENDPOINT_NAME"] = endpoint_resource_name
+    replacements["CONFIG_NAME"] = config1_resource_name
+    replacements["MODEL_NAME"] = model_resource_name
+
+    model = load_resource_file(
+        SERVICE_NAME, "xgboost_model", additional_replacements=replacements
+    )
+    logging.debug(model)
+
+    config = load_resource_file(
+        SERVICE_NAME,
+        "endpoint_config_single_variant",
+        additional_replacements=replacements,
+    )
+    logging.debug(config)
+
+    endpoint_spec = load_resource_file(
+        SERVICE_NAME, "endpoint_base", additional_replacements=replacements
+    )
+    logging.debug(endpoint_spec)
+
+    # Create the k8s resources
+    model_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        MODEL_RESOURCE_PLURAL,
+        model_resource_name,
+        namespace="default",
+    )
+    model_resource = k8s.create_custom_resource(model_reference, model)
+    model_resource = k8s.wait_resource_consumed_by_controller(model_reference)
+    assert model_resource is not None
+
+    config1_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CONFIG_RESOURCE_PLURAL,
+        config1_resource_name,
+        namespace="default",
+    )
+    config1_resource = k8s.create_custom_resource(config1_reference, config)
+    config1_resource = k8s.wait_resource_consumed_by_controller(config1_reference)
+    assert config1_resource is not None
+
+    config2_resource_name = random_suffix_name("2-single-variant-endpoint", 32)
+    config["metadata"]["name"] = config["spec"][
+        "endpointConfigName"
+    ] = config2_resource_name
+    logging.debug(config)
+    config2_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CONFIG_RESOURCE_PLURAL,
+        config2_resource_name,
+        namespace="default",
+    )
+    config2_resource = k8s.create_custom_resource(config2_reference, config)
+    config2_resource = k8s.wait_resource_consumed_by_controller(config2_reference)
+    assert config2_resource is not None
+
+    endpoint_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        ENDPOINT_RESOURCE_PLURAL,
+        endpoint_resource_name,
+        namespace="default",
+    )
+    endpoint_resource = k8s.create_custom_resource(endpoint_reference, endpoint_spec)
+    endpoint_resource = k8s.wait_resource_consumed_by_controller(endpoint_reference)
+    assert endpoint_resource is not None
+
+    yield (endpoint_reference, endpoint_resource, endpoint_spec, config2_resource_name)
+
+    # Delete the k8s resource if not already deleted by tests
+    for cr in (model_reference, config1_reference, config2_reference, endpoint_reference):
+        try:
+            k8s.delete_custom_resource(cr)
+        except:
+            pass
+
+
+@service_marker
+@pytest.mark.canary
+class TestEndpoint:
+    status_creating: str = "Creating"
+    status_inservice: str = "InService"
+    status_udpating: str = "Updating"
+
+    def _get_resource_endpoint_arn(self, resource: Dict):
+        assert (
+            "ackResourceMetadata" in resource["status"]
+            and "arn" in resource["status"]["ackResourceMetadata"]
+        )
+        return resource["status"]["ackResourceMetadata"]["arn"]
+
+    def _describe_sagemaker_endpoint(self, sagemaker_client, endpoint_name: str):
+        try:
+            return sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
+        except BaseException:
+            logging.error(
+                f"SageMaker could not find a endpoint with the name {endpoint_name}"
+            )
+            return None
+
+    def _wait_resource_endpoint_status(
+        self,
+        reference: k8s.CustomResourceReference,
+        expected_status: str,
+        wait_periods: int = 18,
+    ):
+        resource_status = None
+        for _ in range(wait_periods):
+            time.sleep(30)
+            resource = k8s.get_resource(reference)
+            assert "endpointStatus" in resource["status"]
+            resource_status = resource["status"]["endpointStatus"]
+            if resource_status == expected_status:
+                break
+        else:
+            logging.error(
+                f"Wait for endpoint resource status: {expected_status} timed out. Actual status: {resource_status}"
+            )
+
+        return resource_status
+
+    def _wait_sagemaker_endpoint_status(
+        self,
+        sagemaker_client,
+        endpoint_name,
+        expected_status: str,
+        wait_periods: int = 18,
+    ):
+        actual_status = None
+        for _ in range(wait_periods):
+            time.sleep(30)
+            actual_status = sagemaker_client.describe_endpoint(
+                EndpointName=endpoint_name
+            )["EndpointStatus"]
+            if actual_status == expected_status:
+                break
+        else:
+            logging.error(
+                f"Wait for sagemaker endpoint status: {expected_status} timed out. Actual status: {actual_status}"
+            )
+
+        return actual_status
+
+    def _assert_endpoint_status_in_sync(
+        self, sagemaker_client, endpoint_name, reference, expected_status
+    ):
+        assert (
+            self._wait_sagemaker_endpoint_status(
+                sagemaker_client, endpoint_name, expected_status
+            )
+            == self._wait_resource_endpoint_status(reference, expected_status)
+            == expected_status
+        )
+
+    def test_create_endpoint(self, single_variant_xgboost_endpoint):
+        assert k8s.get_resource_exists(single_variant_xgboost_endpoint[0])
+
+    def test_endpoint_has_correct_arn_and_status(
+        self, sagemaker_client, single_variant_xgboost_endpoint
+    ):
+        (reference, _, _, _) = single_variant_xgboost_endpoint
+        resource = k8s.get_resource(reference)
+        endpoint_name = resource["spec"].get("endpointName", None)
+
+        assert endpoint_name is not None
+
+        assert (
+            self._get_resource_endpoint_arn(resource)
+            == self._describe_sagemaker_endpoint(sagemaker_client, endpoint_name)[
+                "EndpointArn"
+            ]
+        )
+
+        self._assert_endpoint_status_in_sync(
+            sagemaker_client, endpoint_name, reference, self.status_creating
+        )
+        self._assert_endpoint_status_in_sync(
+            sagemaker_client, endpoint_name, reference, self.status_inservice
+        )
+
+    def test_update_endpoint(self, sagemaker_client, single_variant_xgboost_endpoint):
+        (
+            reference,
+            resource,
+            endpoint_spec,
+            config2_resource_name,
+        ) = single_variant_xgboost_endpoint
+        endpoint_spec["spec"]["endpointConfigName"] = config2_resource_name
+        resource = k8s.patch_custom_resource(reference, endpoint_spec)
+        resource = k8s.wait_resource_consumed_by_controller(reference)
+        assert resource is not None
+
+        self._assert_endpoint_status_in_sync(
+            sagemaker_client, reference.name, reference, self.status_udpating
+        )
+        self._assert_endpoint_status_in_sync(
+            sagemaker_client, reference.name, reference, self.status_inservice
+        )
+
+    def test_delete_endpoint(self, sagemaker_client, single_variant_xgboost_endpoint):
+        (reference, _, _, _) = single_variant_xgboost_endpoint
+        resource = k8s.get_resource(reference)
+        endpoint_name = resource["spec"].get("endpointName", None)
+
+        # Delete the k8s resource.
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        assert (
+            self._describe_sagemaker_endpoint(sagemaker_client, endpoint_name) is None
+        )

--- a/test/e2e/sagemaker/tests/test_endpoint_config.py
+++ b/test/e2e/sagemaker/tests/test_endpoint_config.py
@@ -1,0 +1,142 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the SageMaker EndpointConfig API.
+"""
+
+import boto3
+import pytest
+import logging
+from typing import Dict
+
+from sagemaker import (
+    SERVICE_NAME,
+    service_marker,
+    CRD_GROUP,
+    CRD_VERSION,
+    CONFIG_RESOURCE_PLURAL,
+    MODEL_RESOURCE_PLURAL,
+)
+from sagemaker.replacement_values import REPLACEMENT_VALUES
+from common.resources import load_resource_file, random_suffix_name
+from common import k8s
+
+
+@pytest.fixture(scope="module")
+def sagemaker_client():
+    return boto3.client("sagemaker")
+
+
+@pytest.fixture(scope="module")
+def single_variant_config():
+    config_resource_name = random_suffix_name("single-variant-config", 32)
+    model_resource_name = config_resource_name + "-model"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CONFIG_NAME"] = config_resource_name
+    replacements["MODEL_NAME"] = model_resource_name
+
+    model = load_resource_file(
+        SERVICE_NAME, "xgboost_model", additional_replacements=replacements
+    )
+    logging.debug(model)
+
+    config = load_resource_file(
+        SERVICE_NAME,
+        "endpoint_config_single_variant",
+        additional_replacements=replacements,
+    )
+    logging.debug(config)
+
+    # Create the k8s resources
+    model_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        MODEL_RESOURCE_PLURAL,
+        model_resource_name,
+        namespace="default",
+    )
+    model_resource = k8s.create_custom_resource(model_reference, model)
+    model_resource = k8s.wait_resource_consumed_by_controller(model_reference)
+    assert model_resource is not None
+
+    config_reference = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        CONFIG_RESOURCE_PLURAL,
+        config_resource_name,
+        namespace="default",
+    )
+    config_resource = k8s.create_custom_resource(config_reference, config)
+    config_resource = k8s.wait_resource_consumed_by_controller(config_reference)
+    assert config_resource is not None
+
+    yield (config_reference, config_resource)
+
+    # Delete the k8s resource if not already deleted by tests
+    try:
+        k8s.delete_custom_resource(model_reference)
+        k8s.delete_custom_resource(config_reference)
+    except:
+        pass
+
+
+@service_marker
+@pytest.mark.canary
+class TestEndpointConfig:
+    def _get_resource_endpoint_config_arn(self, resource: Dict):
+        assert (
+            "ackResourceMetadata" in resource["status"]
+            and "arn" in resource["status"]["ackResourceMetadata"]
+        )
+        return resource["status"]["ackResourceMetadata"]["arn"]
+
+    def _get_sagemaker_endpoint_config_arn(self, sagemaker_client, config_name: str):
+        try:
+            response = sagemaker_client.describe_endpoint_config(
+                EndpointConfigName=config_name
+            )
+            return response["EndpointConfigArn"]
+        except BaseException:
+            logging.error(
+                f"SageMaker could not find a config with the name {config_name}"
+            )
+            return None
+
+    def test_create_endpoint_config(self, single_variant_config):
+        (reference, resource) = single_variant_config
+        assert k8s.get_resource_exists(reference)
+
+    def test_config_has_correct_arn(self, sagemaker_client, single_variant_config):
+        (reference, _) = single_variant_config
+        resource = k8s.get_resource(reference)
+        config_name = resource["spec"].get("endpointConfigName", None)
+
+        assert config_name is not None
+
+        assert self._get_resource_endpoint_config_arn(
+            resource
+        ) == self._get_sagemaker_endpoint_config_arn(sagemaker_client, config_name)
+
+    def test_config_is_deleted(self, sagemaker_client, single_variant_config):
+        (reference, _) = single_variant_config
+        resource = k8s.get_resource(reference)
+        config_name = resource["spec"].get("endpointConfigName", None)
+
+        # Delete the k8s resource.
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        assert (
+            self._get_sagemaker_endpoint_config_arn(sagemaker_client, config_name)
+            is None
+        )

--- a/test/e2e/sagemaker/tests/test_model.py
+++ b/test/e2e/sagemaker/tests/test_model.py
@@ -4,7 +4,7 @@
 # not use this file except in compliance with the License. A copy of the
 # License is located at
 #
-#	 http://aws.amazon.com/apache2.0/
+# 	 http://aws.amazon.com/apache2.0/
 #
 # or in the "license" file accompanying this file. This file is distributed
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
@@ -16,19 +16,19 @@
 import boto3
 import pytest
 import logging
+import time
 from typing import Dict
 
 from sagemaker import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from sagemaker import MODEL_RESOURCE_PLURAL as RESOURCE_PLURAL
 from sagemaker.replacement_values import REPLACEMENT_VALUES
 from common.resources import load_resource_file, random_suffix_name
 from common import k8s
 
-RESOURCE_PLURAL = 'models'
-
 
 @pytest.fixture(scope="module")
 def sagemaker_client():
-    return boto3.client('sagemaker')
+    return boto3.client("sagemaker")
 
 
 @pytest.fixture(scope="module")
@@ -39,12 +39,14 @@ def xgboost_model():
     replacements["MODEL_NAME"] = resource_name
 
     model = load_resource_file(
-        SERVICE_NAME, "xgboost_model", additional_replacements=replacements)
+        SERVICE_NAME, "xgboost_model", additional_replacements=replacements
+    )
     logging.debug(model)
 
     # Create the k8s resource
     reference = k8s.CustomResourceReference(
-        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default")
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+    )
     resource = k8s.create_custom_resource(reference, model)
     resource = k8s.wait_resource_consumed_by_controller(reference)
 
@@ -63,17 +65,20 @@ def xgboost_model():
 @pytest.mark.canary
 class TestModel:
     def _get_resource_model_arn(self, resource: Dict):
-        assert 'ackResourceMetadata' in resource['status'] and \
-            'arn' in resource['status']['ackResourceMetadata']
-        return resource['status']['ackResourceMetadata']['arn']
+        assert (
+            "ackResourceMetadata" in resource["status"]
+            and "arn" in resource["status"]["ackResourceMetadata"]
+        )
+        return resource["status"]["ackResourceMetadata"]["arn"]
 
     def _get_sagemaker_model_arn(self, sagemaker_client, model_name: str):
         try:
             model = sagemaker_client.describe_model(ModelName=model_name)
-            return model['ModelArn']
+            return model["ModelArn"]
         except BaseException:
             logging.error(
-                f"SageMaker could not find a model with the name {model_name}")
+                f"SageMaker could not find a model with the name {model_name}"
+            )
             return None
 
     def test_create_model(self, xgboost_model):
@@ -83,12 +88,21 @@ class TestModel:
     def test_model_has_correct_arn(self, sagemaker_client, xgboost_model):
         (reference, _) = xgboost_model
         resource = k8s.get_resource(reference)
-        model_name = resource['spec'].get('modelName', None)
+        model_name = resource["spec"].get("modelName", None)
 
         assert model_name is not None
 
-        resource_model_arn = self._get_resource_model_arn(resource)
-        expected_model_arn = self._get_sagemaker_model_arn(
-            sagemaker_client, model_name)
+        assert self._get_resource_model_arn(resource) == self._get_sagemaker_model_arn(
+            sagemaker_client, model_name
+        )
 
-        assert resource_model_arn == expected_model_arn
+    def test_model_is_deleted(self, sagemaker_client, xgboost_model):
+        (reference, _) = xgboost_model
+        resource = k8s.get_resource(reference)
+        model_name = resource["spec"].get("modelName", None)
+
+        # Delete the k8s resource.
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        assert self._get_sagemaker_model_arn(sagemaker_client, model_name) is None

--- a/test/e2e/sagemaker/tests/test_processingjob.py
+++ b/test/e2e/sagemaker/tests/test_processingjob.py
@@ -4,7 +4,7 @@
 # not use this file except in compliance with the License. A copy of the
 # License is located at
 #
-#	 http://aws.amazon.com/apache2.0/
+# 	 http://aws.amazon.com/apache2.0/
 #
 # or in the "license" file accompanying this file. This file is distributed
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
@@ -24,12 +24,12 @@ from sagemaker.replacement_values import REPLACEMENT_VALUES
 from common.resources import load_resource_file, random_suffix_name
 from common import k8s
 
-RESOURCE_PLURAL = 'processingjobs'
+RESOURCE_PLURAL = "processingjobs"
 
 
 @pytest.fixture(scope="module")
 def sagemaker_client():
-    return boto3.client('sagemaker')
+    return boto3.client("sagemaker")
 
 
 @pytest.fixture(scope="module")
@@ -40,12 +40,14 @@ def kmeans_processing_job():
     replacements["PROCESSING_JOB_NAME"] = resource_name
 
     processing_job = load_resource_file(
-        SERVICE_NAME, "kmeans_processingjob", additional_replacements=replacements)
+        SERVICE_NAME, "kmeans_processingjob", additional_replacements=replacements
+    )
     logging.debug(processing_job)
 
     # Create the k8s resource
     reference = k8s.CustomResourceReference(
-        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default")
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+    )
     resource = k8s.create_custom_resource(reference, processing_job)
     resource = k8s.wait_resource_consumed_by_controller(reference)
 
@@ -65,71 +67,92 @@ def kmeans_processing_job():
 class TestProcessingJob:
     def _get_created_processing_job_status_list(self):
         return ["InProgress", "Completed"]
-    
+
     def _get_stopped_processing_job_status_list(self):
         return ["Stopped", "Stopping"]
 
-    def _get_sagemaker_processing_job_arn(self, sagemaker_client, processing_job_name: str):
+    def _get_sagemaker_processing_job_arn(
+        self, sagemaker_client, processing_job_name: str
+    ):
         try:
-            processing_job = sagemaker_client.describe_processing_job(ProcessingJobName=processing_job_name)
-            return processing_job['ProcessingJobArn']
+            processing_job = sagemaker_client.describe_processing_job(
+                ProcessingJobName=processing_job_name
+            )
+            return processing_job["ProcessingJobArn"]
         except BaseException:
             logging.error(
-                f"SageMaker could not find a processing job with the name {processing_job_name}")
+                f"SageMaker could not find a processing job with the name {processing_job_name}"
+            )
             return None
 
-    def _get_sagemaker_processing_job_status(self, sagemaker_client, processing_job_name: str):
+    def _get_sagemaker_processing_job_status(
+        self, sagemaker_client, processing_job_name: str
+    ):
         try:
-            processing_job = sagemaker_client.describe_processing_job(ProcessingJobName=processing_job_name)
-            return processing_job['ProcessingJobStatus']
+            processing_job = sagemaker_client.describe_processing_job(
+                ProcessingJobName=processing_job_name
+            )
+            return processing_job["ProcessingJobStatus"]
         except BaseException:
             logging.error(
-                f"SageMaker could not find a processing job with the name {processing_job_name}")
+                f"SageMaker could not find a processing job with the name {processing_job_name}"
+            )
             return None
 
     def test_create_processing_job(self, kmeans_processing_job):
         (reference, resource) = kmeans_processing_job
         assert k8s.get_resource_exists(reference)
 
-    def test_processing_job_has_correct_arn(self, sagemaker_client, kmeans_processing_job):
+    def test_processing_job_has_correct_arn(
+        self, sagemaker_client, kmeans_processing_job
+    ):
         (reference, _) = kmeans_processing_job
         resource = k8s.get_resource(reference)
-        processing_job_name = resource['spec'].get('processingJobName', None)
+        processing_job_name = resource["spec"].get("processingJobName", None)
 
         assert processing_job_name is not None
 
         resource_processing_job_arn = k8s.get_resource_arn(resource)
         expected_processing_job_arn = self._get_sagemaker_processing_job_arn(
-            sagemaker_client, processing_job_name)
+            sagemaker_client, processing_job_name
+        )
 
         assert resource_processing_job_arn == expected_processing_job_arn
 
-    def test_processing_job_has_created_status(self, sagemaker_client, kmeans_processing_job):
+    def test_processing_job_has_created_status(
+        self, sagemaker_client, kmeans_processing_job
+    ):
         (reference, _) = kmeans_processing_job
         resource = k8s.get_resource(reference)
-        processing_job_name = resource['spec'].get('processingJobName', None)
+        processing_job_name = resource["spec"].get("processingJobName", None)
 
         assert processing_job_name is not None
 
         current_processing_job_status = self._get_sagemaker_processing_job_status(
-            sagemaker_client, processing_job_name)
-        expected_processing_job_status_list = self._get_created_processing_job_status_list()
+            sagemaker_client, processing_job_name
+        )
+        expected_processing_job_status_list = (
+            self._get_created_processing_job_status_list()
+        )
         assert current_processing_job_status in expected_processing_job_status_list
-        
 
-    def test_processing_job_has_stopped_status(self, sagemaker_client, kmeans_processing_job):
+    def test_processing_job_has_stopped_status(
+        self, sagemaker_client, kmeans_processing_job
+    ):
         (reference, _) = kmeans_processing_job
         resource = k8s.get_resource(reference)
-        processing_job_name = resource['spec'].get('processingJobName', None)
+        processing_job_name = resource["spec"].get("processingJobName", None)
 
         assert processing_job_name is not None
 
         # Delete the k8s resource.
-        k8s.delete_custom_resource(reference)
-        # TODO: This sleep could be replaced by a wait loop but this is sufficient for now.
-        time.sleep(5)
-        
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
         current_processing_job_status = self._get_sagemaker_processing_job_status(
-            sagemaker_client, processing_job_name)
-        expected_processing_job_status_list = self._get_stopped_processing_job_status_list()
+            sagemaker_client, processing_job_name
+        )
+        expected_processing_job_status_list = (
+            self._get_stopped_processing_job_status_list()
+        )
         assert current_processing_job_status in expected_processing_job_status_list

--- a/test/e2e/sagemaker/tests/test_trainingjob.py
+++ b/test/e2e/sagemaker/tests/test_trainingjob.py
@@ -4,7 +4,7 @@
 # not use this file except in compliance with the License. A copy of the
 # License is located at
 #
-#	 http://aws.amazon.com/apache2.0/
+# 	 http://aws.amazon.com/apache2.0/
 #
 # or in the "license" file accompanying this file. This file is distributed
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
@@ -24,12 +24,12 @@ from sagemaker.replacement_values import REPLACEMENT_VALUES
 from common.resources import load_resource_file, random_suffix_name
 from common import k8s
 
-RESOURCE_PLURAL = 'trainingjobs'
+RESOURCE_PLURAL = "trainingjobs"
 
 
 @pytest.fixture(scope="module")
 def sagemaker_client():
-    return boto3.client('sagemaker')
+    return boto3.client("sagemaker")
 
 
 @pytest.fixture(scope="module")
@@ -40,18 +40,20 @@ def xgboost_trainingjob():
     replacements["TRAINING_JOB_NAME"] = resource_name
 
     trainingjob = load_resource_file(
-        SERVICE_NAME, "xgboost_trainingjob", additional_replacements=replacements)
+        SERVICE_NAME, "xgboost_trainingjob", additional_replacements=replacements
+    )
     logging.debug(trainingjob)
 
     # Create the k8s resource
     reference = k8s.CustomResourceReference(
-        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default")
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+    )
     resource = k8s.create_custom_resource(reference, trainingjob)
     resource = k8s.wait_resource_consumed_by_controller(reference)
 
     assert resource is not None
 
-    yield (reference, resource)    
+    yield (reference, resource)
 
     # Delete the k8s resource if not already deleted by tests
     try:
@@ -65,31 +67,41 @@ def xgboost_trainingjob():
 class TestTrainingJob:
     def _get_created_trainingjob_status_list(self):
         return ["InProgress", "Completed"]
-    
+
     def _get_stopped_trainingjob_status_list(self):
         return ["Stopped", "Stopping"]
 
     def _get_resource_trainingjob_arn(self, resource: Dict):
-        assert 'ackResourceMetadata' in resource['status'] and \
-            'arn' in resource['status']['ackResourceMetadata']
-        return resource['status']['ackResourceMetadata']['arn']
+        assert (
+            "ackResourceMetadata" in resource["status"]
+            and "arn" in resource["status"]["ackResourceMetadata"]
+        )
+        return resource["status"]["ackResourceMetadata"]["arn"]
 
     def _get_sagemaker_trainingjob_arn(self, sagemaker_client, trainingjob_name: str):
         try:
-            trainingjob = sagemaker_client.describe_training_job(TrainingJobName=trainingjob_name)
-            return trainingjob['TrainingJobArn']
+            trainingjob = sagemaker_client.describe_training_job(
+                TrainingJobName=trainingjob_name
+            )
+            return trainingjob["TrainingJobArn"]
         except BaseException:
             logging.error(
-                f"SageMaker could not find a trainingJob with the name {trainingjob_name}")
+                f"SageMaker could not find a trainingJob with the name {trainingjob_name}"
+            )
             return None
 
-    def _get_sagemaker_trainingjob_status(self, sagemaker_client, trainingjob_name: str):
+    def _get_sagemaker_trainingjob_status(
+        self, sagemaker_client, trainingjob_name: str
+    ):
         try:
-            trainingjob = sagemaker_client.describe_training_job(TrainingJobName=trainingjob_name)
-            return trainingjob['TrainingJobStatus']
+            trainingjob = sagemaker_client.describe_training_job(
+                TrainingJobName=trainingjob_name
+            )
+            return trainingjob["TrainingJobStatus"]
         except BaseException:
             logging.error(
-                f"SageMaker could not find a trainingJob with the name {trainingjob_name}")
+                f"SageMaker could not find a trainingJob with the name {trainingjob_name}"
+            )
             return None
 
     def test_create_trainingjob(self, xgboost_trainingjob):
@@ -99,42 +111,47 @@ class TestTrainingJob:
     def test_trainingjob_has_correct_arn(self, sagemaker_client, xgboost_trainingjob):
         (reference, _) = xgboost_trainingjob
         resource = k8s.get_resource(reference)
-        trainingjob_name = resource['spec'].get('trainingJobName', None)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
 
         assert trainingjob_name is not None
 
         resource_trainingjob_arn = k8s.get_resource_arn(resource)
         expected_trainingjob_arn = self._get_sagemaker_trainingjob_arn(
-            sagemaker_client, trainingjob_name)
+            sagemaker_client, trainingjob_name
+        )
 
         assert resource_trainingjob_arn == expected_trainingjob_arn
 
-    def test_trainingjob_has_created_status(self, sagemaker_client, xgboost_trainingjob):
+    def test_trainingjob_has_created_status(
+        self, sagemaker_client, xgboost_trainingjob
+    ):
         (reference, _) = xgboost_trainingjob
         resource = k8s.get_resource(reference)
-        trainingjob_name = resource['spec'].get('trainingJobName', None)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
 
         assert trainingjob_name is not None
 
         current_trainingjob_status = self._get_sagemaker_trainingjob_status(
-            sagemaker_client, trainingjob_name)
+            sagemaker_client, trainingjob_name
+        )
         expected_trainingjob_status_list = self._get_created_trainingjob_status_list()
         assert current_trainingjob_status in expected_trainingjob_status_list
-        
 
-    def test_trainingjob_has_stopped_status(self, sagemaker_client, xgboost_trainingjob):
+    def test_trainingjob_has_stopped_status(
+        self, sagemaker_client, xgboost_trainingjob
+    ):
         (reference, _) = xgboost_trainingjob
         resource = k8s.get_resource(reference)
-        trainingjob_name = resource['spec'].get('trainingJobName', None)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
 
         assert trainingjob_name is not None
 
         # Delete the k8s resource.
-        k8s.delete_custom_resource(reference)
-        # TODO: This sleep could be replaced by a wait loop but this is sufficient for now.
-        time.sleep(5)
-        
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
         current_trainingjob_status = self._get_sagemaker_trainingjob_status(
-            sagemaker_client, trainingjob_name)
+            sagemaker_client, trainingjob_name
+        )
         expected_trainingjob_status_list = self._get_stopped_trainingjob_status_list()
         assert current_trainingjob_status in expected_trainingjob_status_list


### PR DESCRIPTION
### Description of changes:
- Integration tests for endpoint config and endpoint resources in SageMaker
  - Endpointconfig: create, delete
  - Endpoint: create, read, update, delete
- Enhancements:
  - k8s get_resource: it throws an APIException if the resource is not found
  - k8s delete: waits for a resource to be removed from the server
  - k8s patch resource: can be used for testing update operations
  - sagemaker tests: remove sleep for testing delete
  - sagemaker model test: add delete test

### Testing:
Using local kind cluster and pytest

### Notes for the reviewer:
I ran black linting tool by mistake on `sagemaker/tests/` directory but didn't want to mix it in this PR. Please bear with some formatting changes in this PR. I will push another PR after this is merged for lining python files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
