### PR TITLE
Elasticache: enhance logging for test assertion failures

### DIFF
--- a/.github/workflows/e2e-test-elasticache.yaml
+++ b/.github/workflows/e2e-test-elasticache.yaml
@@ -37,6 +37,8 @@ jobs:
           SERVICE: elasticache
       - name: execute elasticache e2e tests
         run: |
+          export AWS_PROFILE=default
+          export AWS_REGION=$(aws configure get region --profile default)
           export TEST_HELM_CHARTS=false
           export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
           export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')

--- a/test/e2e/elasticache/cache_parameter_group/e2e.sh
+++ b/test/e2e/elasticache/cache_parameter_group/e2e.sh
@@ -66,7 +66,8 @@ debug_msg "Testing Add Parameters to Cache Parameter Group: $cpg_name."
 
 assert_no_custom_cache_parameters() {
   local actual_value=$(aws_get_cache_parameters_property "$cpg_name" ".Parameters" "user" | jq length)
-  assert_equal "0" "$actual_value" "Expected: 0 actual: $actual_value found for user parameters in cache parameter group $cpg_name" || exit 1
+  assert_equal "0" "$actual_value" "Expected: 0 actual: $actual_value found for user parameters in cache parameter group $cpg_name" || \
+    log_and_exit "cacheparametergroups/$cpg_name"
 }
 
 ack_set_custom_cache_parameters() {
@@ -166,7 +167,7 @@ debug_msg "Testing delete Cache Parameter Group: $cpg_name."
 
 ack_delete_cache_parameter_group() {
   kubectl delete CacheParameterGroup/"$cpg_name" 2>/dev/null
-  assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+  assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || log_and_exit "cacheparametergroups/$cpg_name"
   sleep 5
 }
 ack_delete_cache_parameter_group

--- a/test/e2e/elasticache/cache_subnet_group/smoke.sh
+++ b/test/e2e/elasticache/cache_subnet_group/smoke.sh
@@ -110,8 +110,7 @@ sleep 20
 actual_subnet_group_desc="$(get_subnet_group_description $aws_resource_name)"
 if [ "$expected_subnet_group_desc" != "$actual_subnet_group_desc" ]; then
   echo "FAIL: expected $aws_resource_name to have been modified in ${service_name}"
-  kubectl logs -n ack-system "$ack_ctrl_pod_id"
-  exit 1
+  log_and_exit "cachesubnetgroups/$aws_resource_name"
 fi
 debug_msg "subnet group $aws_resource_name modified in ${service_name}"
 

--- a/test/e2e/elasticache/replication_group/misc.sh
+++ b/test/e2e/elasticache/replication_group/misc.sh
@@ -50,9 +50,9 @@ EOF
   # ensure resource successfully created and available, check resource is as expected
   wait_and_assert_replication_group_synced_and_available "$rg_id"
   local primary_cluster=$(aws_get_replication_group_json "$rg_id" | jq -r -e ".MemberClusters[0]")
-  assert_equal "0" "$?" "Could not find cache cluster for replication group $rg_id" || exit 1
+  assert_equal "0" "$?" "Could not find cache cluster for replication group $rg_id" || log_and_exit "replicationgroups/$rg_id"
   daws elasticache describe-cache-clusters --cache-cluster-id "$primary_cluster" | jq -r '.CacheClusters[0]' | grep "$sg_id"
-  assert_equal "0" "$?" "Expected replication group $rg_id to have security group $sg_id" || exit 1
+  assert_equal "0" "$?" "Expected replication group $rg_id to have security group $sg_id" || log_and_exit "replicationgroups/$rg_id"
 }
 
 # create multiple RGs and check deletion succeeds


### PR DESCRIPTION
Description of changes:
Similar to #696, but also logging an AWS describe call and k8s object state where applicable (in addition to controller logs), to help us debug issues with our e2e test setup on Github Workflows

Also changing config for github workflow (script is complaining about AWS_PROFILE being unbound)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
