### PR TITLE
Elasticache: convert KMS snapshot test to Python

### DIFF
--- a/test/e2e/elasticache/resources/snapshot_kms.yaml
+++ b/test/e2e/elasticache/resources/snapshot_kms.yaml
@@ -1,0 +1,8 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: Snapshot
+metadata:
+  name: $SNAPSHOT_NAME
+spec:
+  snapshotName: $SNAPSHOT_NAME
+  cacheClusterID: $CC_ID
+  kmsKeyID: $KMS_KEY_ID

--- a/test/e2e/elasticache/snapshot/e2e.sh
+++ b/test/e2e/elasticache/snapshot/e2e.sh
@@ -215,61 +215,7 @@ EOF)
   aws_wait_snapshot_deleted "$snapshot_name"
 }
 
-# test snapshot creation while specifying KMS key
-test_snapshot_create_KMS() {
-  debug_msg "executing ${FUNCNAME[0]}"
-
-  # create KMS key and get key ID
-  local output=$(daws kms create-key --output json)
-  assert_equal "0" "$?" "Expected creation of KMS key to succeed" || exit 1
-
-  local key_id=$(echo "$output" | jq -r -e ".KeyMetadata.KeyId")
-  assert_equal "0" "$?" "Key ID does not exist for KMS key" || exit 1
-
-  # delete replication group if it already exists (we want it to be created to below specification)
-  clear_rg_parameter_variables
-  rg_id="snapshot-test-kms"
-  daws elasticache describe-replication-groups --replication-group-id "$rg_id" 1>/dev/null 2>&1
-  if [[ "$?" == "0" ]]; then
-    daws elasticache delete-replication-group --replication-group-id "$rg_id" 1>/dev/null 2>&1
-    aws_wait_replication_group_deleted  "$rg_id" "FAIL: expected replication group $rg_id to have been deleted in ${service_name}"
-  fi
-
-  # create cluster mode disabled replication group for snapshot
-  num_node_groups=1
-  replicas_per_node_group=0
-  automatic_failover_enabled="false"
-  multi_az_enabled="false"
-  provide_replication_group_yaml | kubectl apply -f - 2>&1
-  exit_if_rg_config_application_failed $? "$rg_id"
-  wait_and_assert_replication_group_synced_and_available "$rg_id"
-
-  # create snapshot while specifying KMS key
-  local snapshot_name="snapshot-kms"
-  daws elasticache delete-snapshot --snapshot-name "$snapshot_name" 1>/dev/null 2>&1
-  sleep 10
-  local cc_id="$rg_id-001"
-  local snapshot_yaml=$(cat <<EOF
-apiVersion: elasticache.services.k8s.aws/v1alpha1
-kind: Snapshot
-metadata:
-  name: $snapshot_name
-spec:
-  snapshotName: $snapshot_name
-  cacheClusterID: $cc_id
-  kmsKeyID: $key_id
-EOF)
-  echo "$snapshot_yaml" | kubectl apply -f -
-  assert_equal "0" "$?" "Expected application of $snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$snapshot_name" 10 "$service_name"
-
-  # delete snapshot for case 1 if creation succeeded
-  kubectl delete snapshots/"$snapshot_name"
-  aws_wait_snapshot_deleted "$snapshot_name"
-}
-
 # run tests
 test_snapshot_CRUD
 test_snapshot_CMD_creates #issue: second snapshot doesn't have "status" property - problem with yaml or something else?
 test_snapshot_CME_creates #same issue as above
-test_snapshot_create_KMS #IAM role needs KMS access for this to work

--- a/test/e2e/elasticache/tests/test_snapshot.py
+++ b/test/e2e/elasticache/tests/test_snapshot.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the Elasticache Snapshot resource
+"""
+
+import pytest
+import logging
+import boto3
+
+from common.resources import read_bootstrap_config, random_suffix_name, load_resource_file
+from common import k8s
+from time import sleep
+from elasticache import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from elasticache.service_bootstrap import BootstrapResources
+from elasticache.util import wait_snapshot_deleted
+
+RESOURCE_PLURAL = "snapshots"
+DEFAULT_WAIT_SECS = 30
+
+@pytest.fixture(scope="module")
+def ec_client():
+    ec = boto3.client("elasticache")
+    return ec
+
+# retrieve resources created in the bootstrap step
+@pytest.fixture(scope="module")
+def bootstrap_resources():
+    return BootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+
+# factory for snapshots
+@pytest.fixture(scope="module")
+def make_snapshot():
+    def _make_snapshot(yaml_name, input_dict, snapshot_name):
+        snapshot = load_resource_file(
+            SERVICE_NAME, yaml_name, additional_replacements=input_dict)
+        logging.debug(snapshot)
+
+        reference = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, snapshot_name, namespace="default")
+        _ = k8s.create_custom_resource(reference, snapshot)
+        resource = k8s.wait_resource_consumed_by_controller(reference, wait_periods=10)
+        assert resource is not None
+        return (reference, resource)
+
+    return _make_snapshot
+
+# setup/teardown for test_snapshot_kms
+@pytest.fixture(scope="module")
+def snapshot_kms(ec_client, bootstrap_resources, make_snapshot):
+    response = ec_client.describe_snapshots(SnapshotName=bootstrap_resources.SnapshotName)
+    cc_id = response['Snapshots'][0]['CacheClusterId']
+
+    snapshot_name = random_suffix_name("ack-snapshot-kms", 32)
+
+    input_dict = {
+        "SNAPSHOT_NAME": snapshot_name,
+        "CC_ID": cc_id,
+        "KMS_KEY_ID": bootstrap_resources.KmsKeyID,
+    }
+
+    (reference, resource) = make_snapshot("snapshot_kms", input_dict, input_dict['SNAPSHOT_NAME'])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    assert wait_snapshot_deleted(snapshot_name)
+
+@service_marker
+class TestSnapshot:
+
+    # test create of snapshot while providing KMS key
+    def test_snapshot_kms(self, snapshot_kms):
+        (reference, _) = snapshot_kms
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=15)

--- a/test/e2e/elasticache/util.py
+++ b/test/e2e/elasticache/util.py
@@ -18,10 +18,11 @@ import boto3
 
 from time import sleep
 
+ec = boto3.client("elasticache")
+
 def wait_usergroup_active(usergroup_id: str,
                            wait_periods: int = 10,
                            period_length: int = 60) -> bool:
-    ec = boto3.client("elasticache")
     for i in range(wait_periods):
         logging.debug(f"Waiting for user group {usergroup_id} to be active ({i})")
         response = ec.describe_user_groups(UserGroupId=usergroup_id)
@@ -43,7 +44,6 @@ def wait_usergroup_active(usergroup_id: str,
 def wait_snapshot_available(snapshot_name: str,
                             wait_periods: int = 10,
                             period_length: int = 60) -> bool:
-    ec = boto3.client("elasticache")
     for i in range(wait_periods):
         logging.debug(f"Waiting for snapshot {snapshot_name} to be available ({i})")
         response = ec.describe_snapshots(SnapshotName=snapshot_name)
@@ -60,4 +60,19 @@ def wait_snapshot_available(snapshot_name: str,
         sleep(period_length)
 
     logging.error(f"Wait for snapshot {snapshot_name} to be available timed out")
+    return False
+
+def wait_snapshot_deleted(snapshot_name: str,
+                          wait_periods: int = 10,
+                          period_length: int = 60) -> bool:
+    for i in range(wait_periods):
+        logging.debug(f"Waiting for snapshot {snapshot_name} to be deleted ({i})")
+        response = ec.describe_snapshots(SnapshotName=snapshot_name)
+
+        if len(response['Snapshots']) == 0:
+            return True
+
+        sleep(period_length)
+
+    logging.error(f"Wait for snapshot {snapshot_name} to be deleted timed out")
     return False


### PR DESCRIPTION
Description of changes:
Converted Snapshot test with KMS key from bash to Python. This test was previously failing due to IAM issues (the test IAM role needs a custom KMS policy attached because the AWS-managed `AWSKeyManagementServicePowerUser` policy is not enough). I'll be following this up with some changes to the `elasticache-controller` repo's `config/iam` directory detailing how to set this up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
