### PR TITLE
Add option to skip python tests and execute bash tests instead

### DIFF
--- a/.github/workflows/e2e-test-elasticache.yaml
+++ b/.github/workflows/e2e-test-elasticache.yaml
@@ -40,6 +40,7 @@ jobs:
           export AWS_PROFILE=default
           export AWS_REGION=$(aws configure get region --profile default)
           export TEST_HELM_CHARTS=false
+          export SKIP_PYTHON_TESTS=true
           export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
           export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
           ./scripts/kind-build-test.sh $SERVICE

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
+# This script runs the existing bash tests for a service controller.
+
 set -eo pipefail
 
 E2E_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$E2E_DIR/../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+# set environment variables
+SKIP_PYTHON_TESTS=${SKIP_PYTHON_TESTS:-"false"}
+RUN_PYTEST_LOCALLY=${RUN_PYTEST_LOCALLY:="false"}
+PYTEST_LOG_LEVEL="${PYTEST_LOG_LEVEL:-"INFO"}"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
 USAGE="
 Usage:
   $(basename "$0") <service>
@@ -11,8 +23,15 @@ Usage:
 's3' 'sns' or 'sqs'
 
 Environment variables:
-  DEBUG:            Set to any value to enable debug logging in the bash tests
-  PYTEST_LOG_LEVEL: Set to any Python logging level for the Python tests.
+  DEBUG:                    Set to any value to enable debug logging in the bash tests
+  SKIP_PYTHON_TESTS         Whether to skip python tests and run bash tests instead for
+                            the service controller (<true|false>)
+                            Default: false
+  RUN_PYTEST_LOCALLY        If python tests exist, whether to run them locally instead of
+                            inside Docker (<true|false>)
+                            Default: false
+  PYTEST_LOG_LEVEL:         Set to any Python logging level for the Python tests.
+                            Default: INFO
 "
 
 if [ $# -ne 1 ]; then
@@ -21,26 +40,21 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+# construct and validate service directory path
 SERVICE="$1"
-
 service_test_dir="$E2E_DIR/$SERVICE"
-
 if [ ! -d "$service_test_dir" ]; then
     echo "No tests for service $SERVICE"
     exit 0
 fi
 
-# check to see if the tests use pytest
-[[ -f "$service_test_dir/__init__.py" ]] && enable_python_tests="true" || enable_python_tests="false"
+# check if python tests exist for the service
+[[ -f "$service_test_dir/__init__.py" ]] && python_tests_exist="true" || python_tests_exist="false"
 
-# find all files except under helper directory
-service_test_files=$( find "$service_test_dir" -name helper -prune -false -o -type f ! -name '.*' | sort )
-
-if [[ "$enable_python_tests" == "false" ]]; then
-  ROOT_DIR="$E2E_DIR/../.."
-  SCRIPTS_DIR="$ROOT_DIR/scripts"
-  source "$SCRIPTS_DIR/lib/common.sh"
-
+# run tests
+if [[ "$python_tests_exist" == "false" ]] || [[ "$SKIP_PYTHON_TESTS" == "true" ]]; then
+  echo "running bash tests..."
+  service_test_files=$( find "$service_test_dir" -type f -name '*.sh' | sort )
   for service_test_file in $service_test_files; do
       test_name=$( filenoext "$service_test_file" )
       test_start_time=$( date +%s )
@@ -48,14 +62,17 @@ if [[ "$enable_python_tests" == "false" ]]; then
       test_end_time=$( date +%s )
       echo "$test_name took $( expr $test_end_time - $test_start_time ) second(s)"
   done
-else
-  PYTEST_LOG_LEVEL="${PYTEST_LOG_LEVEL:-"INFO"}"
+
+elif [[ "$RUN_PYTEST_LOCALLY" == "true" ]]; then
+  echo "running python tests locally..."
   python bootstrap.py "${SERVICE}"
-
   set +e
-
   PYTHONPATH=. pytest -n auto --dist loadfile --log-cli-level "${PYTEST_LOG_LEVEL}" "${SERVICE}"
   python cleanup.py "${SERVICE}"
-
   set -eo pipefail
+
+else
+  echo "running python tests in Docker..."
+  $E2E_DIR/build-run-test-dockerfile.sh $AWS_SERVICE
+
 fi


### PR DESCRIPTION
Description of changes: 

- Add option to skip python tests and execute bash tests instead: the default behavior remains to execute the python tests, but now that can be overridden if `SKIP_PYTHON_TESTS` is set `true`.
- Update usage message
- Remove invocation of python tests from `run-tests.sh` and clean up script

Regarding `run-tests.sh`: I removed the check for an `__init__.py` file since this check already exists in `kind-build-test.sh`; it was pretty confusing that even if `enable_python_tests` was set `false`, `run-tests.sh` would be executed and go on to execute python tests anyway (if they exist for the service). 

In other words, `enable_python_tests="true"` means "run the python tests inside Docker" – there's no change there. However, before, `enable_python_tests="false"` meant "run python tests normally if they exist; otherwise, run bash tests". With these changes, `enable_python_tests="false"` will actually mean "don't run python tests, but run bash tests instead". 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
