### PR TITLE
Fix automated Docker-Python tests

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -127,7 +127,7 @@ helm_output_dir="$SERVICE_CONTROLLER_SOURCE_PATH/helm"
 # not affect the release artifacts produced from `ack-generate release`.
 # TODO(jaypipes): Clean this up so the `ack-generate release` command
 # doesn't need to look up a go.mod file for aws-sdk-go version.
-ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --templates-dir $TEMPLATES_DIR --aws-sdk-go-version v1.35.5"
+ag_args="$SERVICE $RELEASE_VERSION -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --aws-sdk-go-version v1.35.5"
 if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
     ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
 fi

--- a/test/e2e/build-run-test-dockerfile.sh
+++ b/test/e2e/build-run-test-dockerfile.sh
@@ -25,7 +25,7 @@ KUBECONFIG_LOCATION="${KUBECONFIG:-"$HOME/.kube/config"}"
 # Ensure we are inside the correct build context
 pushd "${THIS_DIR}" 1> /dev/null
   # Build the dockerfile first
-  TEST_DOCKER_SHA="$(docker build . --quiet )"
+  TEST_DOCKER_SHA="$(docker build . --quiet)"
 popd 1>/dev/null
 
 # Ensure it can connect to KIND cluster on host device by running on host 
@@ -40,4 +40,5 @@ docker run --rm -it \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
     -e AWS_SESSION_TOKEN \
+    -e RUN_PYTEST_LOCALLY="true" \
     $TEST_DOCKER_SHA "${SERVICE}"

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -13,8 +13,6 @@ SKIP_PYTHON_TESTS=${SKIP_PYTHON_TESTS:-"false"}
 RUN_PYTEST_LOCALLY=${RUN_PYTEST_LOCALLY:="false"}
 PYTEST_LOG_LEVEL="${PYTEST_LOG_LEVEL:-"INFO"}"
 
-source "$SCRIPTS_DIR/lib/common.sh"
-
 USAGE="
 Usage:
   $(basename "$0") <service>
@@ -53,6 +51,8 @@ fi
 
 # run tests
 if [[ "$python_tests_exist" == "false" ]] || [[ "$SKIP_PYTHON_TESTS" == "true" ]]; then
+  source "$SCRIPTS_DIR/lib/common.sh"
+
   echo "running bash tests..."
   service_test_files=$( find "$service_test_dir" -type f -name '*.sh' | sort )
   for service_test_file in $service_test_files; do


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The automated Python E2E tests (running within a Docker container) were attempting to create a child container, themselves. I fixed this recursion by setting the `RUN_PYTEST_LOCALLY` flag to `true`.
Also, we cannot `source` `common.sh` inside the testing container, so I have moved this call back into the local bash test conditional body.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
