### PR TITLE
ElastiCache Auth Token Test

### DIFF
--- a/test/e2e/common/k8s.py
+++ b/test/e2e/common/k8s.py
@@ -15,7 +15,7 @@ CustomResource APIs.
 """
 
 import logging
-
+import base64
 from time import sleep
 from typing import Dict, Optional, Union
 from dataclasses import dataclass
@@ -196,6 +196,42 @@ def get_resource_arn(resource: object) -> Union[None, str]:
         return resource['status']['ackResourceMetadata']['arn']
     return None
 
+
+def create_opaque_secret(namespace: str,
+                         name: str,
+                         key: str,
+                         value: str):
+    """
+    Create new k8 Opaque Secret.
+
+    :param namespace: Namespace of the secret.
+    :param name: Name of the secret
+    :param key: Key of the secret
+    :param value: Value of the secret
+    :return: None
+    """
+    _api_client = _get_k8s_api_client()
+    body = client.V1Secret()
+    body.api_version = 'v1'
+    body.data = {key:base64.b64encode(value.encode('ascii')).decode('utf-8')}
+    body.kind = 'Secret'
+    body.metadata = {'name': name}
+    body.type = 'Opaque'
+    body = _api_client.sanitize_for_serialization(body)
+    client.CoreV1Api(_api_client).create_namespaced_secret(namespace,body)
+
+
+def delete_secret(namespace: str,
+                  name: str):
+    """
+    Delete an existing k8 secret.
+
+    :param namespace: Namespace of the secret.
+    :param name: Name of the secret
+    :return: None
+    """
+    _api_client = _get_k8s_api_client()
+    client.CoreV1Api(_api_client).delete_namespaced_secret(name, namespace)
 
 def wait_on_condition(reference: CustomResourceReference,
                       condition_name: str,

--- a/test/e2e/elasticache/resources/replicationgroup_authtoken.yaml
+++ b/test/e2e/elasticache/resources/replicationgroup_authtoken.yaml
@@ -1,0 +1,17 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+    engine: redis
+    replicationGroupID: $RG_ID
+    replicationGroupDescription: Auth token test
+    cacheNodeType: cache.t3.micro
+    numNodeGroups: 1
+    replicasPerNodeGroup: 0
+    transitEncryptionEnabled: true
+    cacheSubnetGroupName: default
+    authToken:
+      namespace: default
+      name: $NAME
+      key: $KEY


### PR DESCRIPTION
Basic Create/Update Auth token tests.

```
elasticache/tests/test_replicationgroup.py::TestReplicationGroup::test_rg_auth_token 
[gw0] [100%] PASSED elasticache/tests/test_replicationgroup.py::TestReplicationGroup::test_rg_auth_token 

============== 1 passed in 843.54s (0:14:03) =================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
