### PR TITLE
Elasticache: replication group large cluster test and support for skipping slow tests by default

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -18,7 +18,7 @@ from common import k8s
 
 
 def pytest_addoption(parser):
-    pass
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
 
 def pytest_configure(config):
@@ -28,6 +28,17 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "service(arg): mark test associated with a given service"
     )
+    config.addinivalue_line(
+        "markers", "slow: mark test as slow to run"
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 # Provide a k8s client to interact with the integration test cluster
 @pytest.fixture(scope='class')

--- a/test/e2e/elasticache/resources/replicationgroup_largecluster.yaml
+++ b/test/e2e/elasticache/resources/replicationgroup_largecluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  numNodeGroups: $NUM_NODE_GROUPS
+  replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
+  replicationGroupDescription: large cluster mode enabled RG
+  replicationGroupID: $RG_ID

--- a/test/e2e/elasticache/tests/test_replicationgroup_largecluster.py
+++ b/test/e2e/elasticache/tests/test_replicationgroup_largecluster.py
@@ -1,0 +1,73 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Large cluster test for replication group resource
+"""
+
+import pytest
+
+from time import sleep
+from common import k8s
+from elasticache.tests.test_replicationgroup import make_replication_group, rg_deletion_waiter, make_rg_name, DEFAULT_WAIT_SECS
+from elasticache.util import provide_node_group_configuration
+
+@pytest.fixture(scope="module")
+def rg_largecluster_input(make_rg_name):
+    return {
+        "RG_ID": make_rg_name("rg-large-cluster"),
+        "NUM_NODE_GROUPS": "125",
+        "REPLICAS_PER_NODE_GROUP": "3"
+    }
+
+@pytest.fixture(scope="module")
+def rg_largecluster(rg_largecluster_input, make_replication_group, rg_deletion_waiter):
+    input_dict = rg_largecluster_input
+
+    (reference, resource) = make_replication_group("replicationgroup_largecluster", input_dict, input_dict["RG_ID"])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"])
+
+class TestReplicationGroupLargeCluster:
+
+    @pytest.mark.slow
+    def test_rg_largecluster(self, rg_largecluster_input, rg_largecluster):
+        (reference, _) = rg_largecluster
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=240)
+
+        # assertions after initial creation
+        desired_node_groups = int(rg_largecluster_input['NUM_NODE_GROUPS'])
+        desired_replica_count = int(rg_largecluster_input['REPLICAS_PER_NODE_GROUP'])
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes
+
+        # update, wait for resource to sync
+        desired_node_groups = desired_node_groups - 10
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        patch = {"spec": {"numNodeGroups": desired_node_groups,
+                          "nodeGroupConfiguration": provide_node_group_configuration(desired_node_groups)}}
+        _ = k8s.patch_custom_resource(reference, patch)
+        sleep(DEFAULT_WAIT_SECS) # required as controller has likely not placed the resource in modifying
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=240)
+
+        # assert new state after scaling in
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes

--- a/test/e2e/elasticache/util.py
+++ b/test/e2e/elasticache/util.py
@@ -76,3 +76,10 @@ def wait_snapshot_deleted(snapshot_name: str,
 
     logging.error(f"Wait for snapshot {snapshot_name} to be deleted timed out")
     return False
+
+# provide a basic nodeGroupConfiguration object of desired size
+def provide_node_group_configuration(size: int):
+    ngc = []
+    for i in range(1, size+1):
+        ngc.append({"nodeGroupID": str(i).rjust(4, '0')})
+    return ngc


### PR DESCRIPTION
Description of changes:

- large cluster load test
- add support for a `pytest.mark.slow` marker, and skip these tests by default (we don't want tests like this to run with the rest of the tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
