### PR TITLE
[rds] add create-delete test for DB security group

### DIFF
--- a/test/e2e/rds/resources/db_security_group_simple.yaml
+++ b/test/e2e/rds/resources/db_security_group_simple.yaml
@@ -1,0 +1,8 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBSecurityGroup
+metadata:
+  name: $DB_SECURITY_GROUP_NAME
+spec:
+  name: $DB_SECURITY_GROUP_NAME
+  description: $DB_SECURITY_GROUP_DESC
+


### PR DESCRIPTION
Adds a super simple create, read, and delete test for a DB security
group in the RDS API.

Handling allow and revoke of an EC2 security group or IPRange member of
a DB Security Group will be handled in a followup patch after the
rds-controller's DBSecurityGroup resource manager gets custom code that
handles those attributes.

Issue #237

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
