### PR TITLE
Integration tests for Application Auto Scaling

### DIFF
--- a/test/e2e/applicationautoscaling/__init__.py
+++ b/test/e2e/applicationautoscaling/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import pytest
+
+SERVICE_NAME = "applicationautoscaling"
+CRD_GROUP = "applicationautoscaling.services.k8s.aws"
+CRD_VERSION = "v1alpha1"
+
+# PyTest marker for the current service
+service_marker = pytest.mark.service(arg=SERVICE_NAME)

--- a/test/e2e/applicationautoscaling/bootstrap_resources.py
+++ b/test/e2e/applicationautoscaling/bootstrap_resources.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 @dataclass
 class TestBootstrapResources:
-    pass
+    ScalableDynamoTableName: str
 
 _bootstrap_resources = None
 

--- a/test/e2e/applicationautoscaling/bootstrap_resources.py
+++ b/test/e2e/applicationautoscaling/bootstrap_resources.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Declares the structure of the bootstrapped resources and provides a loader
+for them.
+"""
+
+from applicationautoscaling import SERVICE_NAME
+from common.resources import read_bootstrap_config
+from dataclasses import dataclass
+
+@dataclass
+class TestBootstrapResources:
+    pass
+
+_bootstrap_resources = None
+
+def get_bootstrap_resources():
+    global _bootstrap_resources
+    if _bootstrap_resources is None:
+        _bootstrap_resources = TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+    return _bootstrap_resources

--- a/test/e2e/applicationautoscaling/bootstrap_resources.py
+++ b/test/e2e/applicationautoscaling/bootstrap_resources.py
@@ -20,7 +20,8 @@ from dataclasses import dataclass
 
 @dataclass
 class TestBootstrapResources:
-    ScalableDynamoTableName: str
+    ScalableDynamoTableName: str # To be used for testing RegisterScalableTarget
+    RegisteredDynamoTableName: str # Already registered, for testing scaling policies
 
 _bootstrap_resources = None
 

--- a/test/e2e/applicationautoscaling/replacement_values.py
+++ b/test/e2e/applicationautoscaling/replacement_values.py
@@ -1,0 +1,22 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Stores the values used by each of the integration tests for replacing the
+Application Auto Scaling-specific test variables.
+"""
+
+from common.aws import get_aws_region
+from applicationautoscaling.bootstrap_resources import get_bootstrap_resources
+
+REPLACEMENT_VALUES = {
+    
+}

--- a/test/e2e/applicationautoscaling/resources/dynamodb_scalabletarget.yaml
+++ b/test/e2e/applicationautoscaling/resources/dynamodb_scalabletarget.yaml
@@ -1,0 +1,10 @@
+apiVersion: applicationautoscaling.services.k8s.aws/v1alpha1
+kind: ScalableTarget
+metadata:
+  name: $SCALABLETARGET_NAME
+spec:
+  maxCapacity: 50
+  minCapacity: 10
+  resourceID: "table/$DYNAMODB_TABLE"
+  scalableDimension: "dynamodb:table:WriteCapacityUnits"
+  serviceNamespace: dynamodb

--- a/test/e2e/applicationautoscaling/resources/dynamodb_scalingpolicy.yaml
+++ b/test/e2e/applicationautoscaling/resources/dynamodb_scalingpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: applicationautoscaling.services.k8s.aws/v1alpha1
+kind: ScalingPolicy
+metadata:
+  name: $SCALINGPOLICY_NAME
+spec:
+  policyName: $SCALINGPOLICY_NAME
+  policyType: TargetTrackingScaling
+  resourceID: "table/$DYNAMODB_TABLE"
+  scalableDimension: "dynamodb:table:WriteCapacityUnits"
+  serviceNamespace: dynamodb
+  targetTrackingScalingPolicyConfiguration: 
+    targetValue: 70
+    scaleInCooldown: 60
+    scaleOutCooldown: 60
+    predefinedMetricSpecification: 
+        predefinedMetricType: DynamoDBWriteCapacityUtilization

--- a/test/e2e/applicationautoscaling/service_bootstrap.py
+++ b/test/e2e/applicationautoscaling/service_bootstrap.py
@@ -16,12 +16,18 @@ integration tests.
 
 import boto3
 import logging
+from time import sleep
 
 from common.resources import random_suffix_name
 from common.aws import get_aws_account_id, get_aws_region
 from applicationautoscaling.bootstrap_resources import TestBootstrapResources
 
 def create_dynamodb_table() -> str:
+    """Create a DynamoDB table with a randomised table name.
+
+    Returns:
+        str: The name of the DynamoDB table
+    """
     region = get_aws_region()
     account_id = get_aws_account_id()
     table_name = random_suffix_name(f"ack-autoscaling-table-{region}-{account_id}", 63)
@@ -52,8 +58,42 @@ def create_dynamodb_table() -> str:
 
     return table_name
 
+def wait_for_dynamodb_table_active(table_name: str, wait_periods: int = 6, period_length: int = 5) -> bool:
+    """Wait for the given DynamoDB table to reach ACTIVE status.
+
+    Args:
+        table_name: The DynamoDB table to poll.
+        wait_periods: The number of times to poll for the status.
+        period_length: The delay between polling calls.
+
+    Returns:
+        bool: True if the table reached ACTIVE status.
+    """
+    region = get_aws_region()
+    dynamodb = boto3.client("dynamodb", region_name=region)
+
+    for _ in range(wait_periods):
+        sleep(period_length)
+        table = dynamodb.describe_table(
+            TableName=table_name
+        )
+
+        status = table['Table']['TableStatus']
+        if status == 'ACTIVE':
+            logging.info(f"DynamoDB table {table_name} has reached status {status}")
+            return True
+
+        logging.debug(f"DynamoDB table {table_name} is in status {status}. Waiting...")
+
+    logging.error(
+        f"Wait for DynamoDB table {table_name} to become ACTIVE timed out")
+    return False
+
 def register_scalable_dynamodb_table(table_name: str) -> str:
     """Registers a DynamoDB table as a scalable target.
+
+    Args:
+        table_name: The DynamoDB table to register.
 
     Returns:
         str: The name of the DynamoDB table
@@ -76,7 +116,14 @@ def register_scalable_dynamodb_table(table_name: str) -> str:
 def service_bootstrap() -> dict:
     logging.getLogger().setLevel(logging.INFO)
 
+    scalable_table = create_dynamodb_table()
+    registered_table = create_dynamodb_table()
+
+    if not wait_for_dynamodb_table_active(scalable_table) \
+        or not wait_for_dynamodb_table_active(registered_table):
+        raise Exception("DynamoDB tables did not become ACTIVE")
+
     return TestBootstrapResources(
-        create_dynamodb_table(),
-        register_scalable_dynamodb_table(create_dynamodb_table())
+        scalable_table,
+        register_scalable_dynamodb_table(registered_table)
     ).__dict__

--- a/test/e2e/applicationautoscaling/service_bootstrap.py
+++ b/test/e2e/applicationautoscaling/service_bootstrap.py
@@ -1,0 +1,29 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Bootstraps the resources required to run the Application Auto Scaling
+integration tests.
+"""
+
+import boto3
+import json
+import logging
+
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources
+
+
+def service_bootstrap() -> dict:
+    logging.getLogger().setLevel(logging.INFO)
+
+    return TestBootstrapResources(
+        
+    ).__dict__

--- a/test/e2e/applicationautoscaling/service_cleanup.py
+++ b/test/e2e/applicationautoscaling/service_cleanup.py
@@ -19,9 +19,22 @@ import logging
 from common.aws import get_aws_region
 from applicationautoscaling.bootstrap_resources import TestBootstrapResources
 
+def delete_dynamodb_table(table_name: str):
+    region = get_aws_region()
+    dynamodb = boto3.client("dynamodb", region_name=region)
+
+    dynamodb.delete_table(TableName=table_name)
+
+    logging.info(f"Deleted DynamoDB table {table_name}")
+
 def service_cleanup(config: dict):
     logging.getLogger().setLevel(logging.INFO)
 
     resources = TestBootstrapResources(
         **config
     )
+
+    try:
+        delete_dynamodb_table(resources.ScalableDynamoTableName)
+    except:
+        logging.exception(f"Unable to delete DynamoDB table {resources.ScalableDynamoTableName}")

--- a/test/e2e/applicationautoscaling/service_cleanup.py
+++ b/test/e2e/applicationautoscaling/service_cleanup.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Cleans up the resources created by the Application Auto Scaling bootstrapping process.
+"""
+
+import re
+import boto3
+import logging
+from common.aws import get_aws_region
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources
+
+def service_cleanup(config: dict):
+    logging.getLogger().setLevel(logging.INFO)
+
+    resources = TestBootstrapResources(
+        **config
+    )

--- a/test/e2e/applicationautoscaling/service_cleanup.py
+++ b/test/e2e/applicationautoscaling/service_cleanup.py
@@ -38,3 +38,8 @@ def service_cleanup(config: dict):
         delete_dynamodb_table(resources.ScalableDynamoTableName)
     except:
         logging.exception(f"Unable to delete DynamoDB table {resources.ScalableDynamoTableName}")
+
+    try:
+        delete_dynamodb_table(resources.RegisteredDynamoTableName)
+    except:
+        logging.exception(f"Unable to delete DynamoDB table {resources.RegisteredDynamoTableName}")

--- a/test/e2e/applicationautoscaling/tests/__init__.py
+++ b/test/e2e/applicationautoscaling/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.

--- a/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
@@ -21,8 +21,8 @@ import time
 
 from applicationautoscaling import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
 from applicationautoscaling.replacement_values import REPLACEMENT_VALUES
-from applicationautoscaling.bootstrap_resources import TestBootstrapResources
-from common.resources import load_resource_file, random_suffix_name, read_bootstrap_config
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources, get_bootstrap_resources
+from common.resources import load_resource_file, random_suffix_name
 from common import k8s
 
 RESOURCE_PLURAL = "scalabletargets"
@@ -34,7 +34,7 @@ def applicationautoscaling_client():
 
 @pytest.fixture(scope="module")
 def bootstrap_resources() -> TestBootstrapResources:
-    return TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+    return get_bootstrap_resources()
 
 @service_marker
 @pytest.mark.canary

--- a/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the Application Auto Scaling ScalableTarget API.
+"""
+
+import boto3
+import pytest
+import logging
+from typing import Dict, Tuple
+import time
+
+from applicationautoscaling import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from applicationautoscaling.replacement_values import REPLACEMENT_VALUES
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources
+from common.resources import load_resource_file, random_suffix_name, read_bootstrap_config
+from common import k8s
+
+RESOURCE_PLURAL = "scalabletargets"
+
+
+@pytest.fixture(scope="module")
+def applicationautoscaling_client():
+    return boto3.client("application-autoscaling")
+
+@pytest.fixture(scope="module")
+def bootstrap_resources() -> TestBootstrapResources:
+    return TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+
+@service_marker
+@pytest.mark.canary
+class TestScalableTarget:
+    def _generate_dynamodb_target(self, bootstrap_resources: TestBootstrapResources) -> Tuple[k8s.CustomResourceReference, Dict]:
+        resource_name = random_suffix_name("dynamodb-scalable-target", 32)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["SCALABLETARGET_NAME"] = resource_name
+        replacements["DYNAMODB_TABLE"] = bootstrap_resources.ScalableDynamoTableName
+
+        target = load_resource_file(
+            SERVICE_NAME, "dynamodb_scalabletarget", additional_replacements=replacements
+        )
+        logging.debug(target)
+
+        # Create the k8s resource
+        reference = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+        )
+
+        return (reference, target)
+    
+    def _get_dynamodb_scalable_target_exists(self, applicationautoscaling_client, resource_id: str) -> bool:
+        targets = applicationautoscaling_client.describe_scalable_targets(
+            ServiceNamespace="dynamodb",
+            ResourceIds=[resource_id]
+        )
+        
+        return len(targets["ScalableTargets"]) == 1
+
+    def test_smoke(self, applicationautoscaling_client, bootstrap_resources):
+        (reference, target) = self._generate_dynamodb_target(bootstrap_resources)
+        resource = k8s.create_custom_resource(reference, target)
+        resource = k8s.wait_resource_consumed_by_controller(reference)
+        assert k8s.get_resource_exists(reference)
+
+        resourceId = target["spec"].get("resourceID")
+        assert resourceId is not None
+
+        exists = self._get_dynamodb_scalable_target_exists(applicationautoscaling_client, resourceId)
+        assert exists
+
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        exists = self._get_dynamodb_scalable_target_exists(applicationautoscaling_client, resourceId)
+        assert not exists
+

--- a/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalabletarget.py
@@ -32,10 +32,6 @@ RESOURCE_PLURAL = "scalabletargets"
 def applicationautoscaling_client():
     return boto3.client("application-autoscaling")
 
-@pytest.fixture(scope="module")
-def bootstrap_resources() -> TestBootstrapResources:
-    return get_bootstrap_resources()
-
 @service_marker
 @pytest.mark.canary
 class TestScalableTarget:
@@ -66,8 +62,8 @@ class TestScalableTarget:
         
         return len(targets["ScalableTargets"]) == 1
 
-    def test_smoke(self, applicationautoscaling_client, bootstrap_resources):
-        (reference, target) = self._generate_dynamodb_target(bootstrap_resources)
+    def test_smoke(self, applicationautoscaling_client):
+        (reference, target) = self._generate_dynamodb_target(get_bootstrap_resources())
         resource = k8s.create_custom_resource(reference, target)
         resource = k8s.wait_resource_consumed_by_controller(reference)
         assert k8s.get_resource_exists(reference)

--- a/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
@@ -21,8 +21,8 @@ import time
 
 from applicationautoscaling import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
 from applicationautoscaling.replacement_values import REPLACEMENT_VALUES
-from applicationautoscaling.bootstrap_resources import TestBootstrapResources
-from common.resources import load_resource_file, random_suffix_name, read_bootstrap_config
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources, get_bootstrap_resources
+from common.resources import load_resource_file, random_suffix_name
 from common import k8s
 
 RESOURCE_PLURAL = "scalingpolicies"
@@ -34,7 +34,7 @@ def applicationautoscaling_client():
 
 @pytest.fixture(scope="module")
 def bootstrap_resources() -> TestBootstrapResources:
-    return TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+    return get_bootstrap_resources()
 
 @service_marker
 @pytest.mark.canary

--- a/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the Application Auto Scaling ScalingPolicy API.
+"""
+
+import boto3
+import pytest
+import logging
+from typing import Dict, Tuple
+import time
+
+from applicationautoscaling import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from applicationautoscaling.replacement_values import REPLACEMENT_VALUES
+from applicationautoscaling.bootstrap_resources import TestBootstrapResources
+from common.resources import load_resource_file, random_suffix_name, read_bootstrap_config
+from common import k8s
+
+RESOURCE_PLURAL = "scalingpolicies"
+
+
+@pytest.fixture(scope="module")
+def applicationautoscaling_client():
+    return boto3.client("application-autoscaling")
+
+@pytest.fixture(scope="module")
+def bootstrap_resources() -> TestBootstrapResources:
+    return TestBootstrapResources(**read_bootstrap_config(SERVICE_NAME))
+
+@service_marker
+@pytest.mark.canary
+class TestScalingPolicy:
+    def _generate_dynamodb_policy(self, bootstrap_resources: TestBootstrapResources) -> Tuple[k8s.CustomResourceReference, Dict]:
+        resource_name = random_suffix_name("dynamodb-scaling-policy", 32)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["SCALINGPOLICY_NAME"] = resource_name
+        replacements["DYNAMODB_TABLE"] = bootstrap_resources.ScalableDynamoTableName
+
+        policy = load_resource_file(
+            SERVICE_NAME, "dynamodb_scalingpolicy", additional_replacements=replacements
+        )
+        logging.debug(policy)
+
+        # Create the k8s resource
+        reference = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+        )
+
+        return (reference, policy)
+    
+    def _get_dynamodb_scaling_policy_exists(self, applicationautoscaling_client, policy_name: str) -> bool:
+        targets = applicationautoscaling_client.describe_scaling_policies(
+            ServiceNamespace="dynamodb",
+            PolicyNames=[policy_name]
+        )
+        
+        return len(targets["ScalingPolicies"]) == 1
+
+    def test_smoke(self, applicationautoscaling_client, bootstrap_resources):
+        (reference, policy) = self._generate_dynamodb_policy(bootstrap_resources)
+        resource = k8s.create_custom_resource(reference, policy)
+        resource = k8s.wait_resource_consumed_by_controller(reference)
+        assert k8s.get_resource_exists(reference)
+
+        policyName = policy["spec"].get("policyName")
+        assert policyName is not None
+
+        exists = self._get_dynamodb_scaling_policy_exists(applicationautoscaling_client, policyName)
+        assert exists
+
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        exists = self._get_dynamodb_scaling_policy_exists(applicationautoscaling_client, policyName)
+        assert not exists
+

--- a/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
@@ -44,7 +44,7 @@ class TestScalingPolicy:
 
         replacements = REPLACEMENT_VALUES.copy()
         replacements["SCALINGPOLICY_NAME"] = resource_name
-        replacements["DYNAMODB_TABLE"] = bootstrap_resources.ScalableDynamoTableName
+        replacements["DYNAMODB_TABLE"] = bootstrap_resources.RegisteredDynamoTableName
 
         policy = load_resource_file(
             SERVICE_NAME, "dynamodb_scalingpolicy", additional_replacements=replacements

--- a/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
+++ b/test/e2e/applicationautoscaling/tests/test_scalingpolicy.py
@@ -32,10 +32,6 @@ RESOURCE_PLURAL = "scalingpolicies"
 def applicationautoscaling_client():
     return boto3.client("application-autoscaling")
 
-@pytest.fixture(scope="module")
-def bootstrap_resources() -> TestBootstrapResources:
-    return get_bootstrap_resources()
-
 @service_marker
 @pytest.mark.canary
 class TestScalingPolicy:
@@ -66,8 +62,8 @@ class TestScalingPolicy:
         
         return len(targets["ScalingPolicies"]) == 1
 
-    def test_smoke(self, applicationautoscaling_client, bootstrap_resources):
-        (reference, policy) = self._generate_dynamodb_policy(bootstrap_resources)
+    def test_smoke(self, applicationautoscaling_client):
+        (reference, policy) = self._generate_dynamodb_policy(get_bootstrap_resources())
         resource = k8s.create_custom_resource(reference, policy)
         resource = k8s.wait_resource_consumed_by_controller(reference)
         assert k8s.get_resource_exists(reference)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Bootstrap using two DynamoDB tables
  - One to be used for testing registration of `ScalableTarget`
  - One which is pre-registered as a `ScalableTarget` - for testing `ScalingPolicy`
- Smoke tests using a `WriteCapacityUnits` as the scalable dimension

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
