### PR TITLE
[do-not-merge][SageMakerIntegTest]Add a simple training debugger test

### DIFF
--- a/test/e2e/sagemaker/replacement_values.py
+++ b/test/e2e/sagemaker/replacement_values.py
@@ -42,6 +42,29 @@ XGBOOST_IMAGE_URIS = {
     "sa-east-1": 	    "737474898029.dkr.ecr.sa-east-1.amazonaws.com"
 }
 
+XGBOOST_DEBUGGER_IMAGE_URIS = {
+    "us-west-1": 	    "685455198987.dkr.ecr.us-west-1.amazonaws.com",
+    "us-west-2": 	    "895741380848.dkr.ecr.us-west-2.amazonaws.com",
+    "us-east-1": 	    "503895931360.dkr.ecr.us-east-1.amazonaws.com",
+    "us-east-2": 	    "915447279597.dkr.ecr.us-east-2.amazonaws.com",
+    "ap-east-1": 	    "199566480951.dkr.ecr.ap-east-1.amazonaws.com",
+    "ap-northeast-1": 	"430734990657.dkr.ecr.ap-northeast-1.amazonaws.com",
+    "ap-northeast-2": 	"578805364391.dkr.ecr.ap-northeast-2.amazonaws.com",
+    "ap-south-1": 	    "904829902805.dkr.ecr.ap-south-1.amazonaws.com",
+    "ap-southeast-1": 	"972752614525.dkr.ecr.ap-southeast-1.amazonaws.com",
+    "ap-southeast-2": 	"184798709955.dkr.ecr.ap-southeast-2.amazonaws.com",
+    "ca-central-1": 	"519511493484.dkr.ecr.ca-central-1.amazonaws.com",
+    "cn-north-1": 	    "618459771430.dkr.ecr.cn-north-1.amazonaws.com.cn",
+    "cn-northwest-1": 	"658757709296.dkr.ecr.cn-northwest-1.amazonaws.com.cn",
+    "eu-central-1": 	"482524230118.dkr.ecr.eu-central-1.amazonaws.com",
+    "eu-north-1": 	    "314864569078.dkr.ecr.eu-north-1.amazonaws.com",
+    "eu-west-1": 	    "929884845733.dkr.ecr.eu-west-1.amazonaws.com",
+    "eu-west-2": 	    "250201462417.dkr.ecr.eu-west-2.amazonaws.com",
+    "eu-west-3": 	    "447278800020.dkr.ecr.eu-west-3.amazonaws.com",
+    "me-south-1": 	    "986000313247.dkr.ecr.me-south-1.amazonaws.com",
+    "sa-east-1": 	    "818342061345.dkr.ecr.sa-east-1.amazonaws.com"
+}
+
 PYTORCH_TRAIN_IMAGE_URIS = {
     "us-east-1":        "763104351884.dkr.ecr.us-east-1.amazonaws.com",
     "us-east-2":        "763104351884.dkr.ecr.us-east-2.amazonaws.com",
@@ -70,6 +93,7 @@ PYTORCH_TRAIN_IMAGE_URIS = {
 REPLACEMENT_VALUES = {
     "SAGEMAKER_DATA_BUCKET": get_bootstrap_resources().DataBucketName,
     "XGBOOST_IMAGE_URI": f"{XGBOOST_IMAGE_URIS[get_aws_region()]}/sagemaker-xgboost:1.0-1-cpu-py3",
+    "XGBOOST_DEBUGGER_IMAGE_URI": f"{XGBOOST_DEBUGGER_IMAGE_URIS[get_aws_region()]}/sagemaker-debugger-rules:latest",
     "PYTORCH_TRAIN_IMAGE_URI": f"{PYTORCH_TRAIN_IMAGE_URIS[get_aws_region()]}/pytorch-training:1.5.0-cpu-py36-ubuntu16.04",
     "SAGEMAKER_EXECUTION_ROLE_ARN": get_bootstrap_resources().ExecutionRoleARN
 }

--- a/test/e2e/sagemaker/resources/xgboost_trainingjob_debugger.yaml
+++ b/test/e2e/sagemaker/resources/xgboost_trainingjob_debugger.yaml
@@ -1,0 +1,70 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TrainingJob
+metadata:
+  name: $TRAINING_JOB_NAME
+spec:
+  trainingJobName: $TRAINING_JOB_NAME
+  roleARN: $SAGEMAKER_EXECUTION_ROLE_ARN
+  hyperParameters:
+    max_depth: "5"
+    gamma: "4"
+    eta: "0.2"
+    min_child_weight: "6"
+    silent: "0"
+    objective: "reg:squarederror"
+    subsample: "0.7"
+    num_round: "51"
+  algorithmSpecification:
+    trainingImage: $XGBOOST_IMAGE_URI
+    trainingInputMode: File
+  outputDataConfig:
+    s3OutputPath: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/training/debugger/output
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  inputDataConfig:
+    - channelName: train
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3URI: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/training/train
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+    - channelName: validation
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3URI: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/training/validation
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+  debugHookConfig:
+    s3OutputPath: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/training/debugger/hookconfig
+    collectionConfigurations:
+      - collectionName: feature_importance
+        collectionParameters:
+          name: save_interval
+          value: "5"
+      - collectionName: losses
+        collectionParameters:
+          name: save_interval"
+          value: "500" 
+      - collectionName: average_shap
+        collectionParameters:
+          name: save_interval
+          value: "5" 
+      - collectionName: metrics
+        collectionParameters:
+          name: save_interval
+          value: "5" 
+  debugRuleConfigurations:
+    - ruleConfigurationName: LossNotDecreasing
+      ruleEvaluatorImage: $XGBOOST_DEBUGGER_IMAGE_URIS
+      ruleParameters:
+        collection_names: metrics
+        num_steps: "10"
+        rule_to_invoke: LossNotDecreasing

--- a/test/e2e/sagemaker/tests/test_trainingjob_debugger.py
+++ b/test/e2e/sagemaker/tests/test_trainingjob_debugger.py
@@ -1,0 +1,192 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+"""Integration tests for the SageMaker TrainingJob API with the Debugger Feature.
+"""
+
+import boto3
+import pytest
+import logging
+from typing import Dict
+import time
+
+from sagemaker import SERVICE_NAME, service_marker, CRD_GROUP, CRD_VERSION
+from sagemaker.replacement_values import REPLACEMENT_VALUES
+from common.resources import load_resource_file, random_suffix_name
+from common import k8s
+
+RESOURCE_PLURAL = "trainingjobs"
+
+
+@pytest.fixture(scope="module")
+def sagemaker_client():
+    return boto3.client("sagemaker")
+
+
+@pytest.fixture(scope="module")
+def xgboost_trainingjob_debugger():
+    resource_name = random_suffix_name("xgboost-trainingjob-debugger", 32)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["TRAINING_JOB_NAME"] = resource_name
+
+    trainingjob = load_resource_file(
+        SERVICE_NAME, "xgboost_trainingjob_debugger", additional_replacements=replacements
+    )
+    logging.debug(trainingjob)
+
+    # Create the k8s resource
+    reference = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL, resource_name, namespace="default"
+    )
+    resource = k8s.create_custom_resource(reference, trainingjob)
+    resource = k8s.wait_resource_consumed_by_controller(reference)
+
+    assert resource is not None
+
+    yield (reference, resource)
+
+    # # Delete the k8s resource if not already deleted by tests
+    # try:
+    #     k8s.delete_custom_resource(reference)
+    # except:
+    #     pass
+
+
+@service_marker
+@pytest.mark.canary
+class TestTrainingJobDebugger:
+    def _get_created_trainingjob_status_list(self):
+        return ["InProgress", "Completed"]
+
+    def _get_stopped_trainingjob_status_list(self):
+        return ["Stopped", "Stopping"]
+
+    def _get_created_trainingjob_debugger_status_list(self):
+        return ["InProgress", "NoIssuesFound"]
+
+    def _get_stopped_trainingjob_debugger_status_list(self):
+        return ["Stopped", "Stopping"]
+
+    def _get_resource_trainingjob_arn(self, resource: Dict):
+        assert (
+            "ackResourceMetadata" in resource["status"]
+            and "arn" in resource["status"]["ackResourceMetadata"]
+        )
+        return resource["status"]["ackResourceMetadata"]["arn"]
+
+    def _get_sagemaker_trainingjob_arn(self, sagemaker_client, trainingjob_name: str):
+        try:
+            trainingjob = sagemaker_client.describe_training_job(
+                TrainingJobName=trainingjob_name
+            )
+            return trainingjob["TrainingJobArn"]
+        except BaseException:
+            logging.error(
+                f"SageMaker could not find a trainingJob with the name {trainingjob_name}"
+            )
+            return None
+
+    def _get_sagemaker_trainingjob_status(
+        self, sagemaker_client, trainingjob_name: str
+    ):
+        try:
+            trainingjob = sagemaker_client.describe_training_job(
+                TrainingJobName=trainingjob_name
+            )
+            return trainingjob["TrainingJobStatus"]
+        except BaseException:
+            logging.error(
+                f"SageMaker could not find a trainingJob with the name {trainingjob_name}"
+            )
+            return None
+
+    def _get_sagemaker_trainingjob_debugger_status(
+        self, sagemaker_client, trainingjob_name: str
+    ):
+        try:
+            trainingjob = sagemaker_client.describe_training_job(
+                TrainingJobName=trainingjob_name
+            )
+            return trainingjob["DebugRuleEvaluationStatuses"][0]["RuleEvaluationStatus"]
+        except BaseException:
+            logging.error(
+                f"SageMaker could not find a debugger trainingJob with the name {trainingjob_name}"
+            )
+            return None
+
+    def test_create_trainingjob_debugger(self, xgboost_trainingjob_debugger):
+        (reference, resource) = xgboost_trainingjob_debugger
+        assert k8s.get_resource_exists(reference)
+
+    def test_trainingjob_debugger_has_correct_arn(self, sagemaker_client, xgboost_trainingjob_debugger):
+        (reference, _) = xgboost_trainingjob_debugger
+        resource = k8s.get_resource(reference)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
+
+        assert trainingjob_name is not None
+
+        resource_trainingjob_arn = k8s.get_resource_arn(resource)
+        expected_trainingjob_arn = self._get_sagemaker_trainingjob_arn(
+            sagemaker_client, trainingjob_name
+        )
+
+        assert resource_trainingjob_arn == expected_trainingjob_arn
+
+    def test_trainingjob_debugger_has_created_status(
+        self, sagemaker_client, xgboost_trainingjob_debugger
+    ):
+        (reference, _) = xgboost_trainingjob_debugger
+        resource = k8s.get_resource(reference)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
+
+        assert trainingjob_name is not None
+
+        current_trainingjob_status = self._get_sagemaker_trainingjob_status(
+            sagemaker_client, trainingjob_name
+        )
+        expected_trainingjob_status_list = self._get_created_trainingjob_status_list()
+        assert current_trainingjob_status in expected_trainingjob_status_list
+
+    def test_trainingjob__debugger_has_debugger_status(
+        self, sagemaker_client, xgboost_trainingjob_debugger
+    ):
+        (reference, _) = xgboost_trainingjob_debugger
+        resource = k8s.get_resource(reference)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
+
+        assert trainingjob_name is not None
+
+        current_trainingjob_debugger_status = self._get_sagemaker_trainingjob_debugger_status(
+            sagemaker_client, trainingjob_name
+        )
+        expected_trainingjob_debugger_status_list = self._get_created_trainingjob_debugger_status_list()
+        assert current_trainingjob_debugger_status in expected_trainingjob_debugger_status_list
+
+    def test_trainingjob_debugger_has_stopped_status(
+        self, sagemaker_client, xgboost_trainingjob_debugger
+    ):
+        (reference, _) = xgboost_trainingjob_debugger
+        resource = k8s.get_resource(reference)
+        trainingjob_name = resource["spec"].get("trainingJobName", None)
+
+        assert trainingjob_name is not None
+
+        # Delete the k8s resource.
+        _, deleted = k8s.delete_custom_resource(reference)
+        assert deleted is True
+
+        current_trainingjob_debugger_status = self._get_sagemaker_trainingjob_status(
+            sagemaker_client, trainingjob_name
+        )
+        expected_trainingjob_debugger_status_list = self._get_stopped_trainingjob_debugger_status_list()
+        assert current_trainingjob_debugger_status in expected_trainingjob_debugger_status_list


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This follows the same pattern as the trainingjob test and creates a new resources which also uses the debugger fields. Also checks additionally for the debugger status in describe response. 

[TODO] Add required data to the production bucket. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
