### PR TITLE
Add OLM Bundle Generation Scripts

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -66,7 +66,7 @@ Environment variables:
                                         Default: false
   ACK_GENERATE_OLMCONFIG_PATH:          Path to the service OLM configuration file. Ignored
                                         if ACK_GENERATE_OLM is not true.
-                                        Default: {SERVICE_CONTROLLER_SOURCE_PATH}/{SERVICE}-olmconfig.yaml
+                                        Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm/olmconfig.yaml
   ACK_GENERATE_CONFIG_PATH:             Specify a path to the generator config YAML file to
                                         instruct the code generator for the service.
                                         Default: {SERVICE_CONTROLLER_SOURCE_PATH}/generator.yaml
@@ -181,9 +181,8 @@ popd 1>/dev/null
 
 if [[ $ACK_GENERATE_OLM == "true" ]]; then
     echo "Generating operator lifecycle manager bundle assets for $SERVICE"
-    # if the user has specified an olm config use that. Otherwise, use the default one
-    # expected in controller source.
-    DEFAULT_ACK_GENERATE_OLMCONFIG_PATH=$SERVICE_CONTROLLER_SOURCE_PATH/$SERVICE-olmconfig.yaml
+
+    DEFAULT_ACK_GENERATE_OLMCONFIG_PATH="$SERVICE_CONTROLLER_SOURCE_PATH/olm/olmconfig.yaml"
     ACK_GENERATE_OLMCONFIG_PATH=${ACK_GENERATE_OLMCONFIG_PATH:-$DEFAULT_ACK_GENERATE_OLMCONFIG_PATH}
 
     olm_version=$(echo $RELEASE_VERSION | tr -d "v")

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -9,6 +9,7 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
 DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
+ACK_GENERATE_OLM=${ACK_GENERATE_OLM:-"false"}
 
 source "$SCRIPTS_DIR/lib/common.sh"
 source "$SCRIPTS_DIR/lib/k8s.sh"
@@ -16,6 +17,10 @@ source "$SCRIPTS_DIR/lib/helm.sh"
 
 check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
 check_is_installed helm "You can install Helm with the helper scripts/install-helm.sh"
+
+if [[ $ACK_GENERATE_OLM == "true" ]]; then
+    check_is_installed operator-sdk "You can install Operator SDK with the helper scripts/install-operator-sdk.sh"
+fi
 
 if ! k8s_controller_gen_version_equals "$CONTROLLER_TOOLS_VERSION"; then
     echo "FATAL: Existing version of controller-gen "`controller-gen --version`", required version is $CONTROLLER_TOOLS_VERSION."
@@ -31,8 +36,10 @@ ACK_GENERATE_BIN_PATH=${ACK_GENERATE_BIN_PATH:-$DEFAULT_ACK_GENERATE_BIN_PATH}
 ACK_GENERATE_API_VERSION=${ACK_GENERATE_API_VERSION:-"v1alpha1"}
 ACK_GENERATE_CONFIG_PATH=${ACK_GENERATE_CONFIG_PATH:-""}
 ACK_GENERATE_IMAGE_REPOSITORY=${ACK_GENERATE_IMAGE_REPOSITORY:-"$DEFAULT_IMAGE_REPOSITORY"}
+
 DEFAULT_TEMPLATES_DIR="$ROOT_DIR/../../aws-controllers-k8s/code-generator/templates"
 TEMPLATES_DIR=${TEMPLATES_DIR:-$DEFAULT_TEMPLATES_DIR}
+
 
 USAGE="
 Usage:
@@ -55,6 +62,11 @@ Environment variables:
   SERVICE_CONTROLLER_SOURCE_PATH:       Path to the service controller source code
                                         repository.
                                         Default: ../{SERVICE}-controller
+  ACK_GENERATE_OLM:                     Enable Operator Lifecycle Manager generators.
+                                        Default: false
+  ACK_GENERATE_OLMCONFIG_PATH:          Path to the service OLM configuration file. Ignored
+                                        if ACK_GENERATE_OLM is not true.
+                                        Default: {SERVICE_CONTROLLER_SOURCE_PATH}/{SERVICE}-olmconfig.yaml
   ACK_GENERATE_CONFIG_PATH:             Specify a path to the generator config YAML file to
                                         instruct the code generator for the service.
                                         Default: {SERVICE_CONTROLLER_SOURCE_PATH}/generator.yaml
@@ -166,3 +178,16 @@ controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifac
 mv $helm_output_dir/templates/role.yaml $helm_output_dir/templates/cluster-role-controller.yaml
 
 popd 1>/dev/null
+
+if [[ $ACK_GENERATE_OLM == "true" ]]; then
+    echo "Generating operator lifecycle manager bundle assets for $SERVICE"
+    # if the user has specified an olm config use that. Otherwise, use the default one
+    # expected in controller source.
+    DEFAULT_ACK_GENERATE_OLMCONFIG_PATH=$SERVICE_CONTROLLER_SOURCE_PATH/$SERVICE-olmconfig.yaml
+    ACK_GENERATE_OLMCONFIG_PATH=${ACK_GENERATE_OLMCONFIG_PATH:-$DEFAULT_ACK_GENERATE_OLMCONFIG_PATH}
+
+    olm_version=$(echo $RELEASE_VERSION | tr -d "v")
+    ag_olm_args="$SERVICE $olm_version -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --olm-config $ACK_GENERATE_OLMCONFIG_PATH --aws-sdk-go-version v1.35.5"
+
+    $ACK_GENERATE_BIN_PATH olm $ag_olm_args
+fi

--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-operator-sdk.sh
+#
+#
+# Installs Operator SDK if not installed. Optional parameters specifies the
+# version of Operator SDK to install. Defaults tot eh value of the environment
+# variable OPERATOR_SDK_VERSION and if that is not set, the value of the
+# DEFAULT_OPERATOR_SDK_VERSION variable.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/operator-sdk
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+DEFAULT_OPERATOR_SDK_VERSION="1.6.1"
+
+source "${SCRIPTS_DIR}/lib/common.sh"
+
+__operator_sdk_version="${1}"
+if [ "x${__operator_sdk_version}" == "x" ]; then
+    __operator_sdk_version=${OPERATOR_SDK_VERSION:-$DEFAULT_OPERATOR_SDK_VERSION}
+fi
+if ! is_installed operator-sdk; then
+    __platform=$(uname | tr '[:upper:]' '[:lower:]')
+    __tmp_install_dir=$(mktemp -d -t install-operator-sdk-XXX)
+    __operator_sdk_url="https://github.com/operator-framework/operator-sdk/releases/download/v${__operator_sdk_version}/operator-sdk_${__platform}_amd64"
+    echo -n "installing operator-sdk from ${__operator_sdk_url} ... "
+    curl -sq -L ${__operator_sdk_url} --output ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
+    chmod +x ${__tmp_install_dir}/operator-sdk_${__platform}_amd64
+    sudo mv ${__tmp_install_dir}/operator-sdk_${__platform}_amd64 /usr/local/bin/operator-sdk
+    echo "ok."
+fi

--- a/scripts/olm-build-bundle-image.sh
+++ b/scripts/olm-build-bundle-image.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+ROOT_DIR=$DIR/..
+BUILD_DATE=$(date +%Y-%m-%dT%H:%M)
+QUIET=${QUIET:-"false"}
+DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
+DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
+
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+source $SCRIPTS_DIR/lib/common.sh
+
+check_is_installed docker
+
+# red hat operator certification requires additional labels and metadata
+# in the bundle container image. 
+
+# details on the required bundle labels
+# https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
+DEFAULT_ADD_RH_CERTIFICATION_LABELS="false"
+ADD_RH_CERTIFICATION_LABELS=${ADD_RH_CERTIFICATION_LABELS:-$DEFAULT_ADD_RH_CERTIFICATION_LABELS}
+
+# details on how versions are reflected by this label.
+# https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+cert_label_openshift_supported_version="com.redhat.openshift.versions"
+DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS="v4.6" # v4.6 and on
+SUPPORTED_OPENSHIFT_VERSIONS=${SUPPORTED_OPENSHIFT_VERSIONS:-$DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS}
+
+# Identifies that the delivery mechanism is the bundle format
+cert_label_operator_bundle_delivery="com.redhat.delivery.operator.bundle"
+DEFAULT_RED_HAT_DELIVERY_BUNDLE="true"
+RED_HAT_DELIVERY_BUNDLE=${RED_HAT_DELIVERY_BUNDLE:-$DEFAULT_RED_HAT_DELIVERY_BUNDLE}
+
+# Do not backport to OpenShift versions prior to v4.5 by default.
+cert_label_deliver_backport="com.redhat.deliver.backport"
+DEFAULT_RED_HAT_DELIVER_BACKPORT="false" # do not list in openshift <v4.5
+RED_HAT_DELIVER_BACKPORT=${RED_HAT_DELIVER_BACKPORT:-$DEFAULT_RED_HAT_DELIVER_BACKPORT}
+
+USAGE="
+Usage:
+  $(basename "$0") <aws_service> <bundle_version>
+
+Builds the Docker image for an ACK service controller. 
+
+Example: $(basename "$0") ecr
+
+<aws_service> should be an AWS Service name (ecr, sns, sqs, petstore, bookstore)
+<bundle_version> an operator lifecycle manager bundle version in semver (0.0.1, 1.0.0)
+
+
+Environment variables:
+  QUIET:                            Build bundle container image quietly (<true|false>)
+                                    Default: false
+  SERVICE_CONTROLLER_SOURCE_PATH:   Path to the service controller source code
+                                    repository.
+                                    Default: ../{SERVICE}-controller
+  DOCKER_REPOSITORY:                Name for the Docker repository to push to 
+                                    Default: $DEFAULT_DOCKER_REPOSITORY
+  BUNDLE_DOCKERFILE_DIR:            Specify the directory where the bundle.Dockerfile exists.
+                                    Default: {SERVICE_CONTROLLER_SOURCE_PATH}}/olm
+  BUNDLE_DOCKER_IMG_TAG:            Bundle container image tag
+                                    Default: \$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  BUNDLE_DOCKER_IMG:                The bundle container image (including the tag).
+                                    Supercedes the use of BUNDLE_DOCKER_IMAGE_TAG
+                                    and DOCKER_REPOSITORY if set.
+                                    Default: $DEFAULT_DOCKER_REPOSITORY:\$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  ADD_RH_CERTIFICATION_LABELS       Adds the certification labels required by Red Hat
+                                    container certification (<true|false>)
+                                    Default: $DEFAULT_ADD_RH_CERTIFICATION_LABELS
+  SUPPORTED_OPENSHIFT_VERSIONS:     Indicates what versions of OpenShift are supported
+                                    Only used if the ADD_RH_CERTIFICATION_LABELS is
+                                    set to true.
+                                    Default: $DEFAULT_SUPPORTED_OPENSHIFT_VERSIONS
+  RED_HAT_DELIVERY_BUNDLE:          Red Hat should deliver the operator as a bundle.
+                                    Only used if the ADD_RH_CERTIFICATION_LABELS is
+                                    set to true.
+                                    Default: $DEFAULT_RED_HAT_DELIVERY_BUNDLE
+  RED_HAT_DELIVER_BACKPORT:         Red Hat should backport the operator to versions of
+                                    OpenShift prior to v4.5. Only used if the
+                                    ADD_RH_CERTIFICATION_LABELS is set to true.
+                                    Default: $DEFAULT_RED_HAT_DELIVER_BACKPORT
+"
+
+if [ $# -ne 2 ]; then
+    echo "AWS_SERVICE or BUNDLE_VERSION is not defined. Script accepts two parameters, the <AWS_SERVICE> and the <BUNDLE_VERSION> to build." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+BUNDLE_VERSION="$2"
+
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$AWS_SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+DEFAULT_BUNDLE_DOCKERFILE_DIR="${SERVICE_CONTROLLER_SOURCE_PATH}/olm"
+BUNDLE_DOCKERFILE_DIR=${BUNDLE_DOCKERFILE_DIR:-$DEFAULT_BUNDLE_DOCKERFILE_DIR}
+BUNDLE_DOCKERFILE="$BUNDLE_DOCKERFILE_DIR/bundle.Dockerfile"
+
+# stop if the dockerfile was not found
+if [ ! -f $BUNDLE_DOCKERFILE ]; then
+  echo "The bundle.Dockerfile was not found at expected path $BUNDLE_DOCKERFILE."
+  exit 1
+fi
+
+DEFAULT_BUNDLE_DOCKER_IMG_TAG="$AWS_SERVICE-bundle-$BUNDLE_VERSION"
+BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
+BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
+
+build_args="--quiet=${QUIET} -t ${BUNDLE_DOCKER_IMG} -f ${BUNDLE_DOCKERFILE} --build-arg build_date=\"$BUILD_DATE\""
+
+if [[ $ADD_RH_CERTIFICATION_LABELS = "true" ]]; then 
+  # add additional labels with values for certification purposes.
+  build_args="$build_args --label=$cert_label_openshift_supported_version=$SUPPORTED_OPENSHIFT_VERSIONS --label=$cert_label_deliver_backport=$RED_HAT_DELIVER_BACKPORT --label=$cert_label_operator_bundle_delivery=$RED_HAT_DELIVERY_BUNDLE"
+fi
+
+if [[ $QUIET = "false" ]]; then
+    echo "building '$AWS_SERVICE' OLM bundle container image with tag: ${BUNDLE_DOCKER_IMG}"
+fi
+
+pushd $BUNDLE_DOCKERFILE_DIR 1>/dev/null
+docker build $build_args .
+
+if [ $? -ne 0 ]; then
+  exit 2
+fi
+
+popd 1>/dev/null

--- a/scripts/olm-build-bundle-image.sh
+++ b/scripts/olm-build-bundle-image.sh
@@ -61,7 +61,7 @@ Environment variables:
   DOCKER_REPOSITORY:                Name for the Docker repository to push to 
                                     Default: $DEFAULT_DOCKER_REPOSITORY
   BUNDLE_DOCKERFILE_DIR:            Specify the directory where the bundle.Dockerfile exists.
-                                    Default: {SERVICE_CONTROLLER_SOURCE_PATH}}/olm
+                                    Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm
   BUNDLE_DOCKER_IMG_TAG:            Bundle container image tag
                                     Default: \$AWS_SERVICE-bundle-\$BUNDLE_VERSION
   BUNDLE_DOCKER_IMG:                The bundle container image (including the tag).

--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -10,13 +10,25 @@ ROOT_DIR="$SCRIPTS_DIR/.."
 BUILD_DIR="$ROOT_DIR/build"
 DEFAULT_BUNDLE_CHANNEL="alpha"
 DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
+PRESERVE=${PRESERVE:-"false"}
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 
 source "$SCRIPTS_DIR/lib/common.sh"
 
+check_is_installed uuidgen
 check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
 check_is_installed operator-sdk "You can install Operator SDK with the helmer scripts/install-operator-sdk.sh"
+
+function clean_up {
+    if [[ "$PRESERVE" == false ]]; then
+        rm -r "$TMP_DIR" || :
+        return
+    fi
+    echo "--"
+    echo "To regenerate bundle with the same kustomize configs, re-run with:
+    \"TMP_DIR=$TMP_DIR\""
+}
 
 USAGE="
 Usage:
@@ -49,6 +61,13 @@ Environment variables:
                                             This should include the registry, namespace, and
                                             image name.
                                             Default: $DEFAULT_CONTROLLER_CONTAINER_REPOSITORY
+  TMP_DIR                                   Directory where kustomize assets will be temporarily
+                                            copied before they are modified and passed to bundle
+                                            generation logic.
+                                            Default: $BUILD_DIR/tmp-olm-{RANDOMSTRING}
+  PRESERVE:                                 Preserves modified kustomize configs for
+                                            inspection. (<true|false>)
+                                            Default: false
   BUNDLE_GENERATE_EXTRA_ARGS                Extra arguments to pass into the command
                                             'operator-sdk generate bundle'.
 "
@@ -63,12 +82,18 @@ SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 VERSION=$2
 BUNDLE_VERSION=${BUNDLE_VERSION:-$VERSION}
 
-
-
 DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$SERVICE-controller"
 SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
 
 BUNDLE_OUTPUT_PATH=${BUNDLE_OUTPUT_PATH:-$SERVICE_CONTROLLER_SOURCE_PATH/olm}
+
+if [ -z "$TMP_DIR" ]; then
+    TMP_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+    TMP_DIR=$BUILD_DIR/tmp-olm-$TMP_ID
+fi
+# if TMP_DIR is provided but doesn't exist, we still use
+# it and create it later.
+tmp_kustomize_config_dir="$TMP_DIR/config"
 
 if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2
@@ -92,7 +117,12 @@ SERVICE_CONTROLLER_CONTAINER_REPOSITORY=${SERVICE_CONTROLLER_CONTAINER_REPOSITOR
 DEFAULT_AWS_SERVICE_DOCKER_IMAGE="$SERVICE_CONTROLLER_CONTAINER_REPOSITORY:$SERVICE-$VERSION"
 AWS_SERVICE_DOCKER_IMG=${AWS_SERVICE_DOCKER_IMG:-$DEFAULT_AWS_SERVICE_DOCKER_IMAGE}
 
-pushd $SERVICE_CONTROLLER_SOURCE_PATH/config/controller 1>/dev/null
+trap "clean_up" EXIT
+
+# prepare the temporary config dir
+mkdir -p $TMP_DIR
+cp -a $SERVICE_CONTROLLER_SOURCE_PATH/config $TMP_DIR
+pushd $tmp_kustomize_config_dir/controller 1>/dev/null
 kustomize edit set image controller="$AWS_SERVICE_DOCKER_IMG"
 popd 1>/dev/null
 
@@ -116,7 +146,7 @@ fi
 # in the controller-specific repositories.
 mkdir -p $BUNDLE_OUTPUT_PATH
 pushd $BUNDLE_OUTPUT_PATH 1> /dev/null
-kustomize build $SERVICE_CONTROLLER_SOURCE_PATH/config/manifests | operator-sdk generate bundle $opsdk_gen_bundle_args 
+kustomize build $tmp_kustomize_config_dir/manifests | operator-sdk generate bundle $opsdk_gen_bundle_args 
 popd 1> /dev/null
 
 operator-sdk bundle validate $BUNDLE_OUTPUT_PATH/bundle

--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+# A script that creates the Operator Lifecycle Manager bundle for a
+# specific ACK service controller
+
+set -eo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+BUILD_DIR="$ROOT_DIR/build"
+DEFAULT_BUNDLE_CHANNEL="alpha"
+DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
+
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+check_is_installed kustomize "You can install kustomize with the helper scripts/install-kustomize.sh"
+check_is_installed operator-sdk "You can install Operator SDK with the helmer scripts/install-operator-sdk.sh"
+
+USAGE="
+Usage:
+  $(basename "$0") <service> <version>
+
+<service> should be an AWS service API aliases that you wish to build -- e.g.
+'s3' 'sns' or 'sqs'
+
+Environment variables:
+  BUNDLE_DEFAULT_CHANNEL                    The default channel to publish the OLM bundle to.
+                                            Default: $DEFAULT_BUNDLE_CHANNEL
+  BUNDLE_VERSION                            The semantic version of the bundle should it need
+                                            to differ from the version of the controller which is
+                                            passed into the script. Optional. If unset, this
+                                            value will match that passed in by the user as the
+                                            <version> parameter (i.e. the controller version)
+  BUNDLE_CHANNELS                           A comma-separated list of channels the bundle belongs
+                                            to (e.g. \"alpha,beta\").
+                                            Default: $DEFAULT_BUNDLE_CHANNEL
+  BUNDLE_OUTPUT_PATH:                       Specify a path for the OLM bundle to output to.
+                                            Default: {SERVICE_CONTROLLER_SOURCE_PATH}/olm
+  AWS_SERVICE_DOCKER_IMG:                   Specify the docker image for the AWS service.
+                                            This should include the registry, namespace,
+                                            image name, and tag. Takes precedence over
+                                            SERVICE_CONTROLLER_CONTAINER_REPOSITORY
+  SERVICE_CONTROLLER_SOURCE_PATH:           Path to the service controller source code
+                                            repository.
+                                            Default: ../{SERVICE}-controller
+  SERVICE_CONTROLLER_CONTAINER_REPOSITORY   The container repository where the controller exists.
+                                            This should include the registry, namespace, and
+                                            image name.
+                                            Default: $DEFAULT_CONTROLLER_CONTAINER_REPOSITORY
+  BUNDLE_GENERATE_EXTRA_ARGS                Extra arguments to pass into the command
+                                            'operator-sdk generate bundle'.
+"
+
+if [ $# -ne 2 ]; then
+    echo "ERROR: $(basename "$0") accepts two parameters, the SERVICE and VERSION" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+VERSION=$2
+BUNDLE_VERSION=${BUNDLE_VERSION:-$VERSION}
+
+
+
+DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH="$ROOT_DIR/../$SERVICE-controller"
+SERVICE_CONTROLLER_SOURCE_PATH=${SERVICE_CONTROLLER_SOURCE_PATH:-$DEFAULT_SERVICE_CONTROLLER_SOURCE_PATH}
+
+BUNDLE_OUTPUT_PATH=${BUNDLE_OUTPUT_PATH:-$SERVICE_CONTROLLER_SOURCE_PATH/olm}
+
+if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
+    echo "Error evaluating SERVICE_CONTROLLER_SOURCE_PATH environment variable:" 1>&2
+    echo "$SERVICE_CONTROLLER_SOURCE_PATH is not a directory." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+# Set controller image. 
+if [ -n "$AWS_SERVICE_DOCKER_IMG" ] && [ -n "$SERVICE_CONTROLLER_CONTAINER_REPOSITORY"] ; then
+  # It's possible to set the repository (i.e. everything except the tag) as well as the
+  # entire path including the tag using AWS_SERVIC_DOCKER_IMG. If the latter is set, it
+  # will take precedence, so inform the user that this will happen in case the usage of
+  # each configurable is unclear before runtime. 
+  echo "both AWS_SERVICE_DOCKER_IMG and SERVICE_CONTROLLER_CONTAINER REPOSITORY are set."
+  echo "AWS_SERVICE_DOCKER_IMG is expected to be more complete and will take precedence."
+  echo "Ignoring SERVICE_CONTROLLER_CONTAINER_REPOSITORY."
+fi
+
+SERVICE_CONTROLLER_CONTAINER_REPOSITORY=${SERVICE_CONTROLLER_CONTAINER_REPOSITORY:-$DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY}
+DEFAULT_AWS_SERVICE_DOCKER_IMAGE="$SERVICE_CONTROLLER_CONTAINER_REPOSITORY:$SERVICE-$VERSION"
+AWS_SERVICE_DOCKER_IMG=${AWS_SERVICE_DOCKER_IMG:-$DEFAULT_AWS_SERVICE_DOCKER_IMAGE}
+
+pushd $SERVICE_CONTROLLER_SOURCE_PATH/config/controller 1>/dev/null
+kustomize edit set image controller="$AWS_SERVICE_DOCKER_IMG"
+popd 1>/dev/null
+
+# prepare bundle generate arguments
+opsdk_gen_bundle_args="--version $BUNDLE_VERSION --package ack-$SERVICE-controller --kustomize-dir $SERVICE_CONTROLLER_SOURCE_PATH/config/manifests --overwrite "
+
+# specify default channel and all channels if not specified by user
+BUNDLE_DEFAULT_CHANNEL=${BUNDLE_DEFAULT_CHANNEL:-$DEFAULT_BUNDLE_CHANNEL}
+BUNDLE_CHANNELS=${BUNDLE_CHANNELS:-$DEFAULT_BUNDLE_CHANNEL}
+
+opsdk_gen_bundle_args="$opsdk_gen_bundle_args --default-channel $DEFAULT_BUNDLE_CHANNEL --channels $BUNDLE_CHANNELS"
+if [ -n "$BUNDLE_GENERATE_EXTRA_ARGS" ]; then
+    opsdk_gen_bundle_args="$opsdk_gen_bundle_args $BUNDLE_GENERATE_EXTRA_ARGS"
+fi
+
+# operator-sdk generate bundle creates a bundle.Dockerfile relative
+# to where it's called and it cannot be changed as of right now.
+# For the time being, keep the bundle.Dockerfile local to the actual
+# bundle assets.
+# TODO(): determine if it makes sense to keep the bundle.Dockerfiles
+# in the controller-specific repositories.
+mkdir -p $BUNDLE_OUTPUT_PATH
+pushd $BUNDLE_OUTPUT_PATH 1> /dev/null
+kustomize build $SERVICE_CONTROLLER_SOURCE_PATH/config/manifests | operator-sdk generate bundle $opsdk_gen_bundle_args 
+popd 1> /dev/null
+
+operator-sdk bundle validate $BUNDLE_OUTPUT_PATH/bundle

--- a/scripts/olm-publish-bundle-image.sh
+++ b/scripts/olm-publish-bundle-image.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPTS_DIR=$DIR
+DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
+DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
+
+source $SCRIPTS_DIR/lib/common.sh
+
+check_is_installed docker
+
+USAGE="
+Usage:
+  $(basename "$0") <AWS_SERVICE> <BUNDLE_VERSION>
+
+Publishes the Docker image for an ACK service OLM bundle. By default, the
+repository will be $DEFAULT_DOCKER_REPOSITORY and the image tag for the
+specific ACK service controller will be ":\$SERVICE-bundle-\$VERSION".
+
+<AWS_SERVICE> AWS Service name (ecr, sns, sqs)
+<BUNDLE_VERSION> OLM bundle version in SemVer (0.0.1, 1.0.0)
+
+Example: 
+export DOCKER_REPOSITORY=aws-controllers-k8s
+$(basename "$0") ecr 0.0.1
+
+Environment variables:
+  DOCKER_REPOSITORY:        Name for the Docker repository to push to 
+                            Default: $DEFAULT_DOCKER_REPOSITORY
+  BUNDLE_DOCKER_IMG_TAG:    Bundle container image tag
+                            Default: \$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+  BUNDLE_DOCKER_IMG:        The bundle container image (including the tag).
+                            Supercedes the use of BUNDLE_DOCKER_IMAGE_TAG
+                            and DOCKER_REPOSITORY if set.
+                            Default: $DEFAULT_DOCKER_REPOSITORY:\$AWS_SERVICE-bundle-\$BUNDLE_VERSION
+"
+
+if [ $# -ne 2 ]; then
+    echo "AWS_SERVICE or BUNDLE_VERSION is not defined. Script accepts two parameters, the <AWS_SERVICE> and the <BUNDLE_VERSION> to build." 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+BUNDLE_VERSION="$2"
+
+DEFAULT_BUNDLE_DOCKER_IMG_TAG="$AWS_SERVICE-bundle-$BUNDLE_VERSION"
+BUNDLE_DOCKER_IMG_TAG=${BUNDLE_DOCKER_IMG_TAG:-$DEFAULT_BUNDLE_DOCKER_IMG_TAG}
+BUNDLE_DOCKER_IMG=${BUNDLE_DOCKER_IMAGE:-$DOCKER_REPOSITORY:$BUNDLE_DOCKER_IMG_TAG}
+
+export BUNDLE_DOCKER_IMG
+${SCRIPTS_DIR}/olm-build-bundle-image.sh ${AWS_SERVICE} ${BUNDLE_VERSION}
+
+echo "Pushing '$AWS_SERVICE' operator lifecycle manager bundle image with tag: ${BUNDLE_DOCKER_IMG_TAG}"
+
+docker push ${BUNDLE_DOCKER_IMG}
+
+if [ $? -ne 0 ]; then
+  exit 2
+fi


### PR DESCRIPTION
Fixes #705 

## Description

This commit adds most of the necessary plumbing for generating OLM artifacts, as well as publishing those artifacts to a container registry. 

This takes advantage of the`ack-generate olm` command and `operator-sdk generate bundle` in order to generate artifacts that should be ready to go into an operator collection like https://github.com/operator-framework/community-operators.

## Change Synopsis

* `install-operator-sdk.sh` - This will install install the Operator SDK binary at the current release version (1.6.1) and is modeled after other similar dependency installation scripts.
* `build-controller-release.sh` - This has been updated to include optional logic to both install operator-sdk and use the `ack-generate olm` command to generate necessary manifest bases to feed a downstream bundle generation. As these are optional, their defaults are set to `false`.
* `olm-create-bundle.sh` - This will  create an OLM bundle using `operator-sdk generate bundle`  on disk by leveraging the manifest bases that are created in the previous step.
* `olm-build-bundle-image.sh` - This will create the corresponding container image from the assets on disk (generated in the previous step). This also has optional variables that will add additional labels necessary for Red Hat operator certification.
* `olm-publish-bundle-image.sh` - This will publish the bundle to a configurable container registry.

## Sample Execution

I did my testing using the `s3-controller` as I already had the necessary OLM config handy. I believe I pulled the `main` branch. 

```shell
# s3-controller directory/repository
$ git rev-parse HEAD
6980337a5e9b2234d4b7355377ead6ab589d0d5b
```

I then added my sample s3 OLM configuration file. I will go through and commit these files to their respective repos (assuming that the source repositories are where these need to go).

```shell
# s3-controller directory/repository
$ cat s3-olmconfig.yaml 
---
annotations:
  capabilityLevel: basic install
  shortDescription: AWS S3 Controller is a Service Controller for Managing AWS S3 Buckets
    in Kubernetes
displayName: AWS Simple Storage Service (S3) for Kubernetes
description: Manage AWS S3 Buckets from within your OpenShift cluster.
  This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
  project. This project is currently in **developer preview**.
samples:
- kind: Bucket
  spec: |
    name: "example-bucket-created-by-ack"
- kind: MultipartUpload
  spec: |
    bucket: "example-bucket-created-by-ack"
      key: "some-key"
maintainers:
- name: "The ACK Team"
  email: "ack@example.com"
```

I enable OLM artifact generation using an environment variable and build a controller release (10.0.0 for this test, as I might be a time traveler from the future =D ). The location of the `*-olmconfig.yaml` is configurable, but I don't need to change it because of where I've placed the file:

```shell
# community directory/repository
$ export ACK_GENERATE_OLM=true
$ ./scripts/build-controller-release.sh s3 10.0.0
Building release artifacts for s3-10.0.0
Generating custom resource definitions for s3
Generating RBAC manifests for s3
Generating operator lifecycle manager bundle assets for s3
```

Double check that our CSV bases have been generated.

```shell
# community directory/repository
$ tree ../s3-controller/config/manifests/
../s3-controller/config/manifests/
├── bases
│   └── ack-s3-controller.clusterserviceversion.yaml
└── kustomization.yaml

1 directory, 2 files
```

From there, I'll need to create the bundle on disk. Note that this section relies on the controller image being set in the deployment manifest, so the script handles updating that based on defaults/environment. It's also possible to customize the bundle version via environment in case it differs from the controller release, but I don't need it here.

```shell
# community directory/repository
$ ./scripts/olm-create-bundle.sh s3 10.0.0
Generating bundle version 10.0.0
Generating bundle manifests
Bundle manifests generated successfully in bundle
Generating bundle metadata
Creating bundle.Dockerfile
Creating bundle/metadata/annotations.yaml
Bundle metadata generated successfully
INFO[0000] Found annotations file                        bundle-dir=build/release/s3/olm/bundle container-tool=docker
INFO[0000] Could not find optional dependencies file     bundle-dir=build/release/s3/olm/bundle container-tool=docker
INFO[0000] All validation tests have completed successfully 

```

Assets are generated in the controller source repo in a directory called `olm`

```shell
$ tree ../s3-controller/olm
../s3-controller/olm
├── bundle
│   ├── manifests
│   │   ├── ack-s3-controller.clusterserviceversion.yaml
│   │   ├── ack-s3-metrics-service_v1_service.yaml
│   │   ├── ack-s3-reader_rbac.authorization.k8s.io_v1_role.yaml
│   │   ├── ack-s3-writer_rbac.authorization.k8s.io_v1_role.yaml
│   │   └── s3.services.k8s.aws_buckets.yaml
│   ├── metadata
│   │   └── annotations.yaml
│   └── tests
│       └── scorecard
│           └── config.yaml
└── bundle.Dockerfile
```

At this point we need to build the bundle image and publish, but the publish script will build it so we'll just use that. The build script allows you to also specify if the RH certification labels should be added to the image. I'm turning it on here, but the default value is false (i.e. don't build the image with the extra labels) I set the docker repository to my own namespace for testing and publish:

```shell
export DOCKER_REPOSITORY=quay.io/komish/aws-controllers-k8s
export ADD_RH_CERTIFICATION_LABELS="true"
$ ./scripts/olm-publish-bundle-image.sh s3 10.0.0
building 's3' OLM bundle container image with tag: quay.io/komish/aws-controllers-k8s:s3-bundle-10.0.0

... build output truncated for brevity ...

Pushing 's3' operator lifecycle manager bundle image with tag: s3-bundle-10.0.0
The push refers to repository [quay.io/komish/aws-controllers-k8s]
4319a9b9bb3d: Pushed 
1c3775fb3ec9: Pushed 
993f51922e08: Pushed 
s3-bundle-10.0.0: digest: sha256:d41682d98e2047784d7a24e06983706f658c41950b433853b10222985f5579aa size: 939

```

Checking the bundle in this case to make sure that it has the necessary labels for certification (here, I'm referring to the top three labels. The rest of the labels are coming from operator-sdk):

```
$ docker inspect quay.io/komish/aws-controllers-k8s:s3-bundle-10.0.0 | jq .[].Config.Labels
{
  "com.redhat.deliver.backport": "false",
  "com.redhat.delivery.operator.bundle": "true",
  "com.redhat.openshift.versions": "v4.6",
  "operators.operatorframework.io.bundle.channel.default.v1": "alpha",
  "operators.operatorframework.io.bundle.channels.v1": "alpha",
  "operators.operatorframework.io.bundle.manifests.v1": "manifests/",
  "operators.operatorframework.io.bundle.mediatype.v1": "registry+v1",
  "operators.operatorframework.io.bundle.metadata.v1": "metadata/",
  "operators.operatorframework.io.bundle.package.v1": "ack-s3-controller",
  "operators.operatorframework.io.metrics.builder": "operator-sdk-v1.4.0+git",
  "operators.operatorframework.io.metrics.mediatype.v1": "metrics+v1",
  "operators.operatorframework.io.metrics.project_layout": "unknown",
  "operators.operatorframework.io.test.config.v1": "tests/scorecard/",
  "operators.operatorframework.io.test.mediatype.v1": "scorecard+v1"
}
```

I also pulled the image locally to make sure it has the right assets (i.e. the ones I pushed)

```
$ docker image save  quay.io/komish/aws-controllers-k8s:s3-bundle-10.0.0 > my-image.tar

$ tar xvf my-image.tar 
9ffd953efb5ed2e9c3b63cbe235ea383389b2e480c822cf59b8ec9a459806dc9/
9ffd953efb5ed2e9c3b63cbe235ea383389b2e480c822cf59b8ec9a459806dc9/VERSION
9ffd953efb5ed2e9c3b63cbe235ea383389b2e480c822cf59b8ec9a459806dc9/json
9ffd953efb5ed2e9c3b63cbe235ea383389b2e480c822cf59b8ec9a459806dc9/layer.tar
a2db863c6a4ca59e0c6fb4862e807df698165e86a451e6e6cdbe1520302f16ef/
a2db863c6a4ca59e0c6fb4862e807df698165e86a451e6e6cdbe1520302f16ef/VERSION
a2db863c6a4ca59e0c6fb4862e807df698165e86a451e6e6cdbe1520302f16ef/json
a2db863c6a4ca59e0c6fb4862e807df698165e86a451e6e6cdbe1520302f16ef/layer.tar
f92c158cd01e5c5728b5d9c392749806d44ba4ca7f9d99eabf76d91e1affd14d/
f92c158cd01e5c5728b5d9c392749806d44ba4ca7f9d99eabf76d91e1affd14d/VERSION
f92c158cd01e5c5728b5d9c392749806d44ba4ca7f9d99eabf76d91e1affd14d/json
f92c158cd01e5c5728b5d9c392749806d44ba4ca7f9d99eabf76d91e1affd14d/layer.tar
f9bc836c26f34f90702b1696d9ff1065005e5be259553e641ee22a69b0c8cc3e.json
manifest.json
repositories

$ find . -name layer.tar -exec tar xvf {} \;
tests/
tests/.wh..wh..opq
tests/scorecard/
tests/scorecard/config.yaml
manifests/
manifests/ack-s3-controller.clusterserviceversion.yaml
manifests/ack-s3-metrics-service_v1_service.yaml
manifests/ack-s3-reader_rbac.authorization.k8s.io_v1_role.yaml
manifests/ack-s3-writer_rbac.authorization.k8s.io_v1_role.yaml
manifests/s3.services.k8s.aws_buckets.yaml
metadata/
metadata/.wh..wh..opq
metadata/annotations.yaml

$ tree tests manifests metadata
tests
└── scorecard
    └── config.yaml
manifests
├── ack-s3-controller.clusterserviceversion.yaml
├── ack-s3-metrics-service_v1_service.yaml
├── ack-s3-reader_rbac.authorization.k8s.io_v1_role.yaml
├── ack-s3-writer_rbac.authorization.k8s.io_v1_role.yaml
└── s3.services.k8s.aws_buckets.yaml
metadata
└── annotations.yaml

1 directory, 7 files
```

## Notes

* Originally, I had this outputting to the community directory in a `build/` folder. I thought I had seen that output location in some existing scripts. That said, I noticed that the helm assets are stored in-repo with the controller source, so I've moved the output to the `$SERVICE_CONTROLLER_SOURCE_PATH/olm`. Let me know if that needs to change.
* I tested against `ack-generate` built from code-generator v0.0.7 as I see the `--template-dirs` flag has changed to `--templates-dir` on `main` and I didn't want to make changes in other places calling this flag until you were ready to do so. 
* There are additional labels and configurations that will need to go  into the controller image build scripts that are not included as a part of this PR. **I will do further testing and submit a future issue+PR** that will optionally add those labels to the controller container image in order to enable Red Hat certification.
* I also need to go through and commit OLM configs for each controller to get us started.
---

[EDIT] Force pushed to squash a commit that just changed permissions on a script to make it executable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
