### PR TITLE
Explicitly specify a generator config path for ack-generate olm

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -188,5 +188,9 @@ if [[ $ACK_GENERATE_OLM == "true" ]]; then
     olm_version=$(echo $RELEASE_VERSION | tr -d "v")
     ag_olm_args="$SERVICE $olm_version -o $SERVICE_CONTROLLER_SOURCE_PATH --template-dirs $TEMPLATES_DIR --olm-config $ACK_GENERATE_OLMCONFIG_PATH --aws-sdk-go-version v1.35.5"
 
+    if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
+        ag_olm_args="$ag_olm_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
+    fi
+
     $ACK_GENERATE_BIN_PATH olm $ag_olm_args
 fi


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**

Unblocks me on the following, but this is not the resolution of that issue.
https://github.com/aws-controllers-k8s/community/issues/744 (specifically: https://github.com/aws-controllers-k8s/community/issues/744#issuecomment-830428118)

**Description of changes:**

This change will update the OLM component of scripts/build-controller-release.sh to explicitly set the path to the generator.yaml. The default value of this option (if unspecified) is to be unset (https://github.com/aws-controllers-k8s/code-generator/blob/main/cmd/ack-generate/command/root.go#L115-L117) which causes the OLM bundle generation logic to incorrectly scaffold things for ignored resources.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
👍 
