### PR TITLE
Bump operator-sdk version to v1.7.1

### DIFF
--- a/scripts/install-operator-sdk.sh
+++ b/scripts/install-operator-sdk.sh
@@ -14,7 +14,7 @@ set -eo pipefail
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
-DEFAULT_OPERATOR_SDK_VERSION="1.6.1"
+DEFAULT_OPERATOR_SDK_VERSION="1.7.1"
 
 source "${SCRIPTS_DIR}/lib/common.sh"
 


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**
N/A

**Description of changes:**
This bumps the operator-sdk version to v1.7.1 (from v1.6.1) when it's downloaded using the dependency install helper scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
👍 