### PR TITLE
Generate common CRDs in Helm release

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -40,6 +40,9 @@ ACK_GENERATE_IMAGE_REPOSITORY=${ACK_GENERATE_IMAGE_REPOSITORY:-"$DEFAULT_IMAGE_R
 DEFAULT_TEMPLATES_DIR="$ROOT_DIR/../../aws-controllers-k8s/code-generator/templates"
 TEMPLATES_DIR=${TEMPLATES_DIR:-$DEFAULT_TEMPLATES_DIR}
 
+DEFAULT_RUNTIME_DIR="$ROOT_DIR/../runtime"
+RUNTIME_DIR=${RUNTIME_DIR:-$DEFAULT_RUNTIME_DIR}
+RUNTIME_API_VERSION=${RUNTIME_API_VERSION:-"v1alpha1"}
 
 USAGE="
 Usage:
@@ -159,6 +162,13 @@ fi
 
 echo "Building release artifacts for $SERVICE-$RELEASE_VERSION"
 $ACK_GENERATE_BIN_PATH release $ag_args
+
+pushd $RUNTIME_DIR/apis/core/$RUNTIME_API_VERSION 1>/dev/null
+
+echo "Generating common custom resource definitions"
+controller-gen crd:allowDangerousTypes=true paths=./... output:crd:artifacts:config=$helm_output_dir/crds
+
+popd 1>/dev/null
 
 pushd $SERVICE_CONTROLLER_SOURCE_PATH/apis/$ACK_GENERATE_API_VERSION 1>/dev/null
 


### PR DESCRIPTION
Issue #, if available: #764

Description of changes:
Ensures the `build-controller-release.sh` script also generates the common core CRDs (in `runtime/apis/core/<version>`) into the Helm directory structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
