### PR TITLE
Fix service controller repo referencing an empty default variable

### DIFF
--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -60,7 +60,7 @@ Environment variables:
   SERVICE_CONTROLLER_CONTAINER_REPOSITORY   The container repository where the controller exists.
                                             This should include the registry, namespace, and
                                             image name.
-                                            Default: $DEFAULT_CONTROLLER_CONTAINER_REPOSITORY
+                                            Default: $DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY
   TMP_DIR                                   Directory where kustomize assets will be temporarily
                                             copied before they are modified and passed to bundle
                                             generation logic.


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**
N/A

**Description of changes:**
The help text for the `SERVICE_CONTROLLER_CONTAINER_REPOSITORY` variable in the olm-create-bundle.sh script refers to an incorrect default value, which renders as empty.

This replaces that variable reference with the correct default `DEFAULT_SERVICE_CONTROLLER_CONTAINER_REPOSITORY`.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.** 👍 
