### PR TITLE
Added check for macos while installing binary.

### DIFF
--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -23,7 +23,7 @@ if [ "x$__kind_version" == "x" ]; then
 fi
 
 if ! is_installed kind; then
-    __kind_url="https://kind.sigs.k8s.io/dl/v${__kind_version}/kind-linux-amd64"
+    __kind_url="https://kind.sigs.k8s.io/dl/v${__kind_version}/kind-$(uname -s|tr '[:upper:]' '[:lower:]')-amd64"
     echo -n "installing kind from $__kind_url ... "
     curl --silent -Lo ./kind "$__kind_url"
     chmod +x ./kind


### PR DESCRIPTION
Issue #, if available:

Description of changes: The script was only installing kind binary for linux while mac alternative exists. The changes will fetch the correct binary for both darwin/linux.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
