### PR TITLE
Fix comparison false positives due to missing space when checking if `AWS_SERVICE_DOCKER_IMG` and `SERVICE_CONTROLLER_CONTAINER_REPOSITORY` are set

### DIFF
--- a/scripts/olm-create-bundle.sh
+++ b/scripts/olm-create-bundle.sh
@@ -102,8 +102,8 @@ if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     exit 1
 fi
 
-# Set controller image. 
-if [ -n "$AWS_SERVICE_DOCKER_IMG" ] && [ -n "$SERVICE_CONTROLLER_CONTAINER_REPOSITORY"] ; then
+# Set controller image.
+if [ -n "$AWS_SERVICE_DOCKER_IMG" ] && [ -n "$SERVICE_CONTROLLER_CONTAINER_REPOSITORY" ] ; then
   # It's possible to set the repository (i.e. everything except the tag) as well as the
   # entire path including the tag using AWS_SERVIC_DOCKER_IMG. If the latter is set, it
   # will take precedence, so inform the user that this will happen in case the usage of


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**
N/A

**Description of changes:**
When running olm-create-bundle.sh with the `AWS_SERVICE_DOCKER_IMG` variable set, but not the `SERVICE_CONTROLLER_CONTAINER_REPOSITORY` set, we still saw informative messages indicating that both were set and that one would take precedence.

The comparison is mostly there to be informative to the pipeline - the underlying behavior still worked as expected.

This was apparently caused by a missing space between one of the comparison operations and the closing `]`. This commit addresses that discrepancy.

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
👍 
