### PR TITLE
Changing proxy as goproxy.io is not deny listed as much.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG build_date
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 # For building Go Module required
-ENV GOPROXY=https://proxy.golang.org,direct
+ENV GOPROXY=https://goproxy.io,direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Changing proxy.golang.org -> goproxy.io (verified working on vpn as well)
```
curl -sSL https://proxy.golang.org/github.com/aws-controllers-k8s/runtime/@v/v0.1.0.info
curl: (6) Could not resolve host: proxy.golang.org
```

```
➜  ~ curl -sSL https://goproxy.io/github.com/aws-controllers-k8s/runtime/@v/v0.1.0.info
{"Version":"v0.1.0","Time":"2021-04-20T17:23:38Z"}%
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
