### PR TITLE
Revert #771 "3d5b481913808159b0302ed5b80cbec0ff455433"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG build_date
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR $work_dir
 # For building Go Module required
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux


### PR DESCRIPTION
Reverts aws-controllers-k8s/community#771

We need to keep using `proxy.golang.org` (Official Go proxy) for building ACK container images. For contributors having troubles to use `proxy.golang.org` they will have to set a different proxy or no-proxy option locally.

Description of changes:
- reverts 3d5b481913808159b0302ed5b80cbec0ff455433

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.