### PR TITLE
Use ACK_ROLE_ARN in place of AWS_ROLE_ARN

### DIFF
--- a/.github/workflows/e2e-test-elasticache.yaml
+++ b/.github/workflows/e2e-test-elasticache.yaml
@@ -41,8 +41,8 @@ jobs:
           export AWS_REGION=$(aws configure get region --profile default)
           export TEST_HELM_CHARTS=false
           export SKIP_PYTHON_TESTS=true
-          export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
-          export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
+          export ACK_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
+          export ACK_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
           ./scripts/kind-build-test.sh $SERVICE
         working-directory: ./aws-controllers-k8s/community
         env:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -35,8 +35,8 @@ jobs:
           SERVICE: ${{ matrix.service }}
       - name: execute e2e tests
         run: |
-          export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
-          export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
+          export ACK_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
+          export ACK_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
           ./scripts/kind-build-test.sh $SERVICE
         env:
           SERVICE: ${{ matrix.service }}

--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ build-controller: build-ack-generate ## Generate controller code for SERVICE
 
 kind-test: export PRESERVE = true
 kind-test: export LOCAL_MODULES = false
-kind-test: ## Run functional tests for SERVICE with AWS_ROLE_ARN
+kind-test: ## Run functional tests for SERVICE with ACK_ROLE_ARN
 	@./scripts/kind-build-test.sh $(AWS_SERVICE)
 
 local-kind-test: export PRESERVE = true
 local-kind-test: export LOCAL_MODULES = true
-local-kind-test: ## Run functional tests for SERVICE with AWS_ROLE_ARN allowing local modules
+local-kind-test: ## Run functional tests for SERVICE with ACK_ROLE_ARN allowing local modules
 	@./scripts/kind-build-test.sh $(AWS_SERVICE)
 
 delete-all-kind-clusters:	## Delete all local kind clusters

--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -118,13 +118,13 @@ To generate the IAM role ARN, do:
 
 ```
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text) && \
-export AWS_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
+export ACK_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
 ```
 
 !!! info 
      The tests uses the `generate_temp_creds` function from the
      `scripts/lib/aws.sh` script, executing effectively 
-     ` aws sts assume-role --role-session-arn $AWS_ROLE_ARN --role-session-name $TEMP_ROLE `
+     ` aws sts assume-role --role-session-arn $ACK_ROLE_ARN --role-session-name $TEMP_ROLE `
      which fetches temporarily `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
      and an `AWS_SESSION_TOKEN` used in turn to authentication the ACK
      controller. The duration of the session token is 900 seconds (15 minutes).
@@ -138,7 +138,7 @@ step.
 
 !!! warning "IAM troubles?!"
     If you try the following command and you see an error message containing
-    something along the line of `AWS_ROLE_ARN is not defined.` then you know
+    something along the line of `ACK_ROLE_ARN is not defined.` then you know
     that somewhere in the IAM setup you either left out a step or one of the
     commands failed.
 

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -12,7 +12,7 @@ ROOT_DIR="$SCRIPTS_DIR/.."
 CLUSTER_NAME_BASE=${CLUSTER_NAME_BASE:-"test"}
 AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-""}
 AWS_REGION=${AWS_REGION:-"us-west-2"}
-AWS_ROLE_ARN=${AWS_ROLE_ARN:-""}
+ACK_ROLE_ARN=${ACK_ROLE_ARN:-""}
 ACK_ENABLE_DEVELOPMENT_LOGGING="true"
 ENABLE_PROMETHEUS=${ENABLE_PROMETHEUS:-"false"}
 TEST_HELM_CHARTS=${TEST_HELM_CHARTS:-"true"}
@@ -69,14 +69,14 @@ function clean_up {
 
 USAGE="
 Usage:
-  export AWS_ROLE_ARN=\"\$ROLE_ARN\"
+  export ACK_ROLE_ARN=\"\$ROLE_ARN\"
   $(basename "$0") <AWS_SERVICE>
 
 Builds the Docker image for an ACK service controller, loads the Docker image
 into a KinD Kubernetes cluster, creates the Deployment artifact for the ACK
 service controller and executes a set of tests.
 
-Example: export AWS_ROLE_ARN=\"\$ROLE_ARN\"; $(basename "$0") ecr
+Example: export ACK_ROLE_ARN=\"\$ROLE_ARN\"; $(basename "$0") ecr
 
 <AWS_SERVICE> should be an AWS Service name (ecr, sns, sqs, petstore, bookstore)
 
@@ -84,7 +84,7 @@ Environment variables:
   SERVICE_CONTROLLER_SOURCE_PATH: Path to the service controller source code
                             repository.
                             Default: ../{SERVICE}-controller
-  AWS_ROLE_ARN:             Provide AWS Role ARN for functional testing on local KinD Cluster. Mandatory.
+  ACK_ROLE_ARN:             Provide AWS Role ARN for functional testing on local KinD Cluster. Mandatory.
   PRESERVE:                 Preserve kind k8s cluster for inspection (<true|false>)
                             Default: false
   LOCAL_MODULES:            Enables use of local modules during AWS Service controller docker image build
@@ -127,8 +127,8 @@ if [[ ! -d $SERVICE_CONTROLLER_SOURCE_PATH ]]; then
     exit 1
 fi
 
-if [ -z "$AWS_ROLE_ARN" ]; then
-    echo "AWS_ROLE_ARN is not defined. Set <AWS_ROLE_ARN> env variable to indicate the ARN of the IAM Role to use in testing"
+if [ -z "$ACK_ROLE_ARN" ]; then
+    echo "ACK_ROLE_ARN is not defined. Set <ACK_ROLE_ARN> env variable to indicate the ARN of the IAM Role to use in testing"
     echo "${USAGE}"
     exit  1
 fi
@@ -177,6 +177,7 @@ trap "clean_up" EXIT
 export AWS_ACCOUNT_ID
 export AWS_REGION
 export AWS_ROLE_ARN
+export ACK_ROLE_ARN
 export ACK_ENABLE_DEVELOPMENT_LOGGING
 export ENABLE_PROMETHEUS
 export ACK_RESOURCE_TAGS

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -40,13 +40,13 @@ aws_check_credentials() {
 aws_generate_temp_creds() {
     __uuid=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 
-    if [ -z "$AWS_ROLE_ARN" ]; then
+    if [ -z "$ACK_ROLE_ARN" ]; then
         printf "Missing input Role ARN, exiting...\n"
         exit 1
     fi
 
     JSON=$(daws sts assume-role \
-           --role-arn "$AWS_ROLE_ARN"  \
+           --role-arn "$ACK_ROLE_ARN"  \
            --role-session-name tmp-role-"$__uuid" \
            --duration-seconds 900 \
            --output json || exit 1)


### PR DESCRIPTION
Issue #, if available:
`AWS_ROLE_ARN` conflicts with existing environment variables mounted to containers when assuming a role through IRSA. This makes it impossible to generate temporary credentials within a Prow job that uses IRSA to authenticate the pod.

Description of changes:
Modified any references to `AWS_ROLE_ARN` to now be `ACK_ROLE_ARN`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
