### PR TITLE
increase role session duration

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -50,7 +50,7 @@ aws_generate_temp_creds() {
     JSON=$(daws sts assume-role \
            --role-arn "$ACK_ROLE_ARN"  \
            --role-session-name tmp-role-"$__uuid" \
-           --duration-seconds 3600 \
+           --duration-seconds 7200 \
            --output json || exit 1)
 
     AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")


### PR DESCRIPTION
Description of changes:
Test parallelism in prow CI is low and it runs only 2-3 tests. sagemaker-controller tests do not finish in one hour as a result. see - https://github.com/aws-controllers-k8s/sagemaker-controller/pull/34. the tests won't be able to clean up the resources as well since the credentials expire which is a big issue

Can we increase the number of threads in addition to this change? CI experience is bad if the developer needs to wait for 2 hours to know their test results

Another solution is to make the session duration and num threads configurable parameter per controller repo if we configure a file that has these env variables in each controller repo


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
