### PR TITLE
Parameterize controller build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Base image to use for the final stage
+ARG base_image=amazonlinux:2
 # Build the manager binary
 FROM golang:1.14.1 as builder
 
@@ -40,7 +42,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
     -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 
-FROM amazonlinux:2
+FROM $base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,3 +1,5 @@
+# Base image to use at runtime
+ARG base_image=amazonlinux:2
 # Build the manager binary
 FROM golang:1.14.1 as builder
 
@@ -52,7 +54,7 @@ RUN GIT_VERSION=$service_controller_git_version && \
     -modfile="${work_dir}/go.local.mod" \
     -a -o $work_dir/bin/controller $work_dir/cmd/controller/main.go
 
-FROM amazonlinux:2
+FROM $base_image
 ARG service_alias
 ARG work_dir=/github.com/aws-controllers-k8s/$service_alias-controller
 WORKDIR /


### PR DESCRIPTION
**Issue #, if available:**
Related to #763, but does not close this issue.

**Description of changes:**

This change adds a new `base_image` argument to all Dockerfiles, and sets the default value of this parameter to the original value of `amazonlinux:2`. This should cause no change for existing build workflows.

According to documentation, this new argument must exist prior to the very first `FROM` in order to be used in a `FROM` action call. https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

This enables developers to build a container from this Dockerfile with an alternate target base image for the final stage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 👍 

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>