### PR TITLE
Capitalise service name in documentation menus

### DIFF
--- a/docs/contents/snippets/reference_overview.md
+++ b/docs/contents/snippets/reference_overview.md
@@ -9,4 +9,4 @@ Resource | API Version
 {% endmacro %}
 
 {% for service in page.meta.services | sort(attribute='name') %}
-{{ render_service(service.name, service.resources) }}{% endfor %}
+{{ render_service(service.service_metadata.service.short_name, service.resources) }}{% endfor %}


### PR DESCRIPTION
Description of changes:
Makes use of the `metadata.yaml` file in each service repository by changing any reference to the SDK service name to the properly capitalised`short_name`. For instance, `sfn` will now be `Step Functions`, `sagemaker` will be `SageMaker`, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
