### PR TITLE
update docs for separate ECR repos and releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,25 @@ resources on your behalf.
 
 ## Getting Started
 
-Currently, there are a set of ACK [service controllers][services] that have
-been released in a `Preview` [maintenance phase][maint-phases]. You may
-[install][install] these controllers in binary form using the Helm charts
-published on our ACK public artifact repository.
+Please see the list of ACK [service controllers][services] currently in one of
+our [project stages][proj-stages].
+
+[proj-stages]: https://aws-controllers-k8s.github.io/community/releases/#project-stages
+
+You can [install][install] any of the controllers in the `RELEASED` project stage using
+Helm (recommended) or manually using the raw Kubernetes manifests contained in
+the individual ACK service controller's source repository.
 
 [services]: https://aws-controllers-k8s.github.io/community/services/
-[maint-phases]: https://aws-controllers-k8s.github.io/community/releases#maintenance-phases
-[install]: https://aws-controllers-k8s.github.io/user-docs/install/
+[install]: https://aws-controllers-k8s.github.io/community/user-docs/install/
 
-If you are comfortable building Go code yourself and working with static
-Kubernetes manifests, you are also free to [test-drive][testing] various
-controllers using our KinD-based end-to-end test suite.
+Once installed, Kubernetes users may apply a custom resource (CR) corresponding
+to one of the resources exposed by the ACK service controller for the service.
 
-[testing]: https://aws-controllers-k8s.github.io/community/dev-docs/testing/
+To view the list of custom resources and each CR's schema, visit our
+[reference documentation][ref-docs].
+
+[ref-docs]: https://aws-controllers-k8s.github.io/community/reference/overview/
 
 ## Help & Feedback
 

--- a/docs/contents/index.md
+++ b/docs/contents/index.md
@@ -6,13 +6,36 @@ managed services for your Kubernetes applications without needing to define
 resources outside of the cluster or run services that provide supporting
 capabilities like databases or message queues within the cluster.
 
-This is a new open source project built with ❤️ by AWS and available as a
-**Developer Preview**. We encourage you to try it out, provide feedback and
-contribute to development.
+This is a fully open source project built with ❤️  by AWS. The project is
+structured as a set of source code repositories containing a
+[common runtime][rt], a [code generator][code-gen], some
+[common testing infrastructure][test-infra] and a series of individual service
+controllers that correspond to AWS services (e.g. the
+[RDS service controller for ACK][rds-controller]).
 
-*Important: Because this project is a preview, there may be significant and
-breaking changes introduced in the future. We encourage you to try and
-experiment with this project. Please do not adopt it for production use.*
+[rt]: https://github.com/aws-controllers-k8s/runtime
+[code-gen]: https://github.com/aws-controllers-k8s/code-generator
+[test-infra]: https://github.com/aws-controllers-k8s/test-infra
+[rds-controller]: https://github.com/aws-controllers-k8s/rds-controller
+
+Individual ACK service controllers are installable as separate binaries either
+manually via raw manifests or via a Helm chart that corresponds to the
+individual service controller.
+
+!!! note **IMPORTANT**
+    Individual ACK service controllers may be in different
+    maintenance phases and follow separate release cadences. Please read our
+    documentation about [project stages][proj-stages] and
+    [maintenance phases][maint-phases] fully, including how we
+    [release and version][rel-ver] our controllers. Controllers in a `PREVIEW`
+    maintenance phase have at least one container image and Helm chart released to
+    an ECR Public repository. However, be aware that controllers in a `PREVIEW`
+    maintenance phase may have significant and breaking changes introduced in a
+    future release.
+
+[proj-stages]: https://aws-controllers-k8s.github.io/community/releases/#project-stages
+[maint-phases]: https://aws-controllers-k8s.github.io/community/releases/#maintenance-phases
+[rel-ver]: https://aws-controllers-k8s.github.io/community/releases/#releases-and-versioning
 
 ## Background
 
@@ -49,16 +72,30 @@ those applications depend.
 
 Read more about [how ACK works][how-it-works].
 
-[gh]: https://github.com/aws/aws-controllers-k8s/
+[gh]: https://github.com/aws-controllers-k8s/community
 [controller]: https://kubernetes.io/docs/reference/glossary/?fundamental=true#term-controller
 [crd]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [how-it-works]: https://aws-controllers-k8s.github.io/community/how-it-works/
 
 ## Getting started
 
-Until we've graduated ACK [service controllers][services] we ask you to [test-drive](https://aws-controllers-k8s.github.io/community/dev-docs/testing/) them.
+Please see the list of ACK [service controllers][services] currently in one of
+our [project stages][proj-stages].
+
+You can [install][install] any of the controllers in the `RELEASED` project stage using
+Helm (recommended) or manually using the raw Kubernetes manifests contained in
+the individual ACK service controller's source repository.
 
 [services]: https://aws-controllers-k8s.github.io/community/services/
+[install]: https://aws-controllers-k8s.github.io/community/user-docs/install/
+
+Once installed, Kubernetes users may apply a custom resource (CR) corresponding
+to one of the resources exposed by the ACK service controller for the service.
+
+To view the list of custom resources and each CR's schema, visit our
+[reference documentation][ref-docs].
+
+[ref-docs]: https://aws-controllers-k8s.github.io/community/reference/overview/
 
 ## Getting help
 

--- a/docs/contents/releases.md
+++ b/docs/contents/releases.md
@@ -134,29 +134,35 @@ This is by design, and [per the Semantic Versioning specification][semver-zero]:
 [semver-zero]: https://semver.org/#spec-item-4
 
 For ACK components that have a binary distributable -- i.e. a Docker image --
-the creation of a new SemVer Git tag on the source code repository will trigger
+the creation of a new SemVer Git tag on the source code repository triggers the
 automatic building and publishing of a Docker image with an image tag including
-the SemVer version. For example, if a Git tag of `v1.2.6` was created on the
+the SemVer version.
+
+For example, if a Git tag of `v1.2.6` was created on the
 [github.com/aws-controllers-k8s/s3-controller][s3-ctrl] repository, a Docker
-image with a tag `s3-v1.2.6` would be published to the
-[aws-controllers-k8s/controller][ecr-ack-ctrl] ECR repository.
+image with a tag `v1.2.6` would be published to the
+[public.ecr.aws/aws-controllers-k8s/s3-controller][ecr-ack-ctrl] ECR Public
+repository.
 
 [s3-ctrl]: https://github.com/aws-controllers-k8s/s3-controller
-[ecr-ack-ctrl]: https://gallery.ecr.aws/aws-controllers-k8s/controller
+[ecr-ack-ctrl]: https://gallery.ecr.aws/aws-controllers-k8s/s3-controller
 
 !!! note
-    Binaries for ACK components are published in our Amazon ECR
-    Public [registry][ecr-ack-ctrl].
+    Binaries for individual ACK service controllers components are published in
+    separate Amazon ECR Public repositories.
 
 For ACK components that have a Helm Chart distributable -- i.e. an ACK service
 controller -- the creation of a new SemVer Git tag on the source code
-repository will trigger automatic building and publishing of a Helm Chart with
-an artifact tag including the SemVer version. For example, a Git tag of
-`v1.2.6` on the [github.com/aws-controllers-k8s/s3-controller][s3-ctrl]
-repository means a Helm chart with a tag `s3-v1.2.6` would be published to the
-[aws-controllers-k8s/chart][ecr-ack-chart] ECR repository.
+repository triggers automatic building and publishing of a Helm Chart with
+an artifact tag including the SemVer version.
 
-[ecr-ack-chart]: https://gallery.ecr.aws/aws-controllers-k8s/chart
+For example, a Git tag of `v1.2.6` on the
+[github.com/aws-controllers-k8s/s3-controller][s3-ctrl]
+repository means a Helm chart with a tag `v1.2.6` would be published to the
+[public.ecr.aws/aws-controllers-k8s/s3-chart][ecr-ack-chart] ECR Public
+repository.
+
+[ecr-ack-chart]: https://gallery.ecr.aws/aws-controllers-k8s/s3-chart
 
 #### A Word About Dependencies
 
@@ -189,14 +195,16 @@ a specific version of the ACK common runtime.
 [recommend-helm]: https://aws-controllers-k8s.github.io/community/user-docs/install/#helm-recommended
 
 Some ACK service controllers will have Helm Charts with a
-`$SERVICE-v$MAJOR_VERSION-stable` tag, referred from here out as just a
+`v$MAJOR_VERSION-stable` tag, referred from here out as just a
 "`stable` artifact tag". There will only be one of these tags for the ACK
-service controller **in a major version series**. For example, the `stable`
-artifact tag for the ElastiCache ACK service controller's "v1" major version
-series would be `elasticache-v1-stable`.
+service controller **in a major version series**. For example, the full
+`stable` artifact tag for the ElastiCache ACK service controller's "v1" major
+version series would be
+`public.ecr.aws/aws-controllers-k8s/elasticache-chart:v1-stable`.
 
 This `stable` artifact tag points to a Helm chart that has configuration values
 that have been tested with a specific SemVer Docker image.
+
 Typically these tests are "soak" tests and allow the team maintaining that ACK
 controller's source code to have a high degree of confidence in the
 controller's long-running operation.
@@ -212,17 +220,17 @@ service controller may update the configuration values and associated SemVer
 Docker image tag for the controller binary to point to a newer image.
 
 For example, consider the ElastiCache ACK service controller maintainer team
-has executed a series of long-running tests of the controller image tagged with
-the `elasticache-v1.2.6` SemVer tag. The maintainer team is confident that the
-controller is stable for production use. In the `stable` Git branch of the
-ElastiCache service controller's source repository, the team would update the
-Helm Chart's Deployment, setting the
-`Deployment.spec.template.spec.containers[0].image` to
-`public.ecr.aws/aws-controllers-k8s/controller/elasticache-v1.2.6`.
+has executed a series of long-running tests of the
+`public.ecr.aws/aws-controllers-k8s/elasticache-controller` image tagged with
+the `v1.2.6` SemVer tag. The maintainer team is confident that the controller
+is stable for production use. In the `stable` Git branch of the ElastiCache
+service controller's source repository, the team would update the Helm Chart's
+Deployment, setting the `Deployment.spec.template.spec.containers[0].image` to
+`public.ecr.aws/aws-controllers-k8s/elasticache-controller:v1.2.6`.
 
 They then package the Helm Chart and publish it as an OCI Artifact to the
-`public.ecr.aws/aws-controllers-k8s/chart` registry, using an OCI artifact tag
-of `elasticache-v1-stable`.
+`public.ecr.aws/aws-controllers-k8s/elasticache-chart` registry, using an OCI
+artifact tag of `v1-stable`.
 
 A couple months later, the maintainer team has added a few minor, non-breaking
 features to their controller along with a number of bug fixes. The latest
@@ -233,10 +241,10 @@ the `v1.3.2` controller image and are confident that this release is
 appropriate for production use. The maintainer team would update the Helm Chart
 in their `stable` Git branch to have its
 `Deployment.spec.template.spec.containers[0].image` set to
-`public.ecr.aws/aws-controllers-k8s/controller/elasticache-v1.3.2`. They would
+`public.ecr.aws/aws-controllers-k8s/elasticache-controller:v1.3.2`. They would
 then package this Helm Chart and push overwrite the
-`public.ecr.aws/aws-controllers-k8s/chart:elasticache-v1-stable` OCI Artifact tag
-to point to this newly-updated Helm Chart that refers to the `v1.3.2`
+`public.ecr.aws/aws-controllers-k8s/elasticache-chart:v1-stable` OCI Artifact
+tag to point to this newly-updated Helm Chart that refers to the `v1.3.2`
 controller image.
 
 ## Maintenance Phases

--- a/docs/contents/services.md
+++ b/docs/contents/services.md
@@ -25,29 +25,29 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 | AWS Service | Project Stage | Maintenance Phase | Next Milestone 
 | ----------- | ------------- | ----------------- | -------------- 
 | Amazon [ACM](#amazon-acm) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/482) | |
-| Amazon [API Gateway V2](#amazon-api-gateway-v2) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/207) | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/15
-| Amazon [Application Auto Scaling](#amazon-application-auto-scaling) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/589) | `PREVIEW` |
-| Amazon [CloudFront Distribution](#amazon-cloudfront-distribution) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/249) | | https://github.com/aws-controllers-k8s/community/milestone/14
-| Amazon [DynamoDB](#amazon-dynamodb) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/2060) | `PREVIEW` |
-| Amazon [ECR](#amazon-ecr) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/208) | `PREVIEW` |
+| Amazon [API Gateway V2](#amazon-api-gateway-v2) | `RELEASED` | `PREVIEW` |
+| Amazon [Application Auto Scaling](#amazon-application-auto-scaling) | `RELEASED` | `PREVIEW` |
+| Amazon [CloudFront Distribution](#amazon-cloudfront-distribution) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/249) | |
+| Amazon [DynamoDB](#amazon-dynamodb) | `RELEASED` | `PREVIEW` |
+| Amazon [ECR](#amazon-ecr) | `RELEASED` | `PREVIEW` |
 | Amazon [EFS](#amazon-efs) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/328) | |
-| Amazon [EKS](#amazon-eks) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/16) | | https://github.com/aws-controllers-k8s/community/milestone/7
-| Amazon [ElastiCache](#amazon-elasticache) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/240) | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/9
-| Amazon [Elasticsearch](#amazon-elasticsearch) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/503) | |
-| Amazon [EC2 VPC](#amazon-ec2-vpc) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/489) | |
+| Amazon [EKS](#amazon-eks) | `IN PROGRESS` | |
+| Amazon [ElastiCache](#amazon-elasticache) | `RELEASED` | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/9
+| Amazon [Elasticsearch Service](#amazon-elasticsearch) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/503) | |
+| Amazon [EC2 VPC](#amazon-ec2-vpc) | `IN PROGRESS` | |
 | AWS [IAM](#aws-iam) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/222) | |
-| AWS [Lambda](#aws-lambda) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/238) | | https://github.com/aws-controllers-k8s/community/milestone/10
+| AWS [Lambda](#aws-lambda) | `IN PROGRESS` | | 
 | AWS [Kinesis](#aws-kinesis) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/235) | |
-| Amazon [KMS](#amazon-kms) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/491) | | https://github.com/aws-controllers-k8s/community/milestone/18
-| Amazon [MQ](#amazon-mq) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/390) | | https://github.com/aws-controllers-k8s/community/milestone/12
-| Amazon [MSK](#amazon-msk) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/348) | | https://github.com/aws-controllers-k8s/community/milestone/13
-| Amazon [RDS](#amazon-rds) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/237) | | https://github.com/aws-controllers-k8s/community/milestone/8
+| Amazon [KMS](#amazon-kms) | `IN PROGRESS` | |
+| Amazon [MQ](#amazon-mq) | `RELEASED` | |
+| Amazon [MSK](#amazon-msk) | [`PLANNED`](https://github.com/aws-controllers-k8s/community/issues/348) | |
+| Amazon [RDS](#amazon-rds) | `RELEASED` | `PREVIEW` |
 | Amazon [Route53](#amazon-route53) | [`PROPOSED`](https://github.com/aws-controllers-k8s/community/issues/480) | |
-| Amazon [SageMaker](#amazon-sagemaker) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/385) | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/11
-| Amazon [SNS](#amazon-sns) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/202) | `PREVIEW` |
-| Amazon [SQS](#amazon-sqs) | [`IN PROGRESS`](https://github.com/aws-controllers-k8s/community/issues/205) | | https://github.com/aws-controllers-k8s/community/milestone/6
-| AWS [Step Functions](#aws-step-functions) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/239) | `PREVIEW` |
-| Amazon [S3](#amazon-s3) | [`RELEASED`](https://github.com/aws-controllers-k8s/community/issues/204) | `PREVIEW` |
+| Amazon [SageMaker](#amazon-sagemaker) | `RELEASED` | `PREVIEW` | https://github.com/aws-controllers-k8s/community/milestone/11
+| Amazon [SNS](#amazon-sns) | `RELEASED` | `PREVIEW` |
+| Amazon [SQS](#amazon-sqs) | `IN PROGRESS` | |
+| AWS [Step Functions](#aws-step-functions) | `RELEASED` | `PREVIEW` |
+| Amazon [S3](#amazon-s3) | `RELEASED` | `PREVIEW` |
 
 !!! note "Don't see a service listed?"
     If you don't see a particular AWS service listed, feel free to
@@ -64,7 +64,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/207
 * Current project stage: `RELEASED`
 * Current maintenance phase: `PREVIEW`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/15
 * AWS service documentation: https://aws.amazon.com/api-gateway/
 * ACK service controller: https://github.com/aws-controllers-k8s/apigatewayv2-controller
 
@@ -79,7 +78,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 ## Amazon CloudFront Distribution
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/249
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/14
 * Current project stage: `PLANNED`
 * AWS service documentation: https://aws.amazon.com/cloudfront/
 
@@ -88,7 +86,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/206
 * Current project stage: `RELEASED`
 * Current maintenance phase: `PREVIEW`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/dynamodb/
 * ACK service controller: https://github.com/aws-controllers-k8s/dynamodb-controller
 
@@ -97,7 +94,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/208
 * Current project stage: `RELEASED`
 * Current maintenance phase: `PREVIEW`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/ecr/
 * ACK service controller: https://github.com/aws-controllers-k8s/ecr-controller
 
@@ -110,7 +106,7 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 ## Amazon EKS
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/16
-* Current project stage: `PLANNED`
+* Current project stage: `IN PROGRESS`
 * AWS service documentation: https://aws.amazon.com/eks/
 
 ## Amazon ElastiCache
@@ -122,17 +118,20 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * AWS service documentation: https://aws.amazon.com/elasticache/
 * ACK service controller: https://github.com/aws-controllers-k8s/elasticache-controller
 
-## Amazon Elasticsearch
+## Amazon Elasticsearch Service
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/503
-* Current project stage: `PROPOSED`
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
 * AWS service documentation: https://aws.amazon.com/elasticsearch-service/
+* ACK service controller: https://github.com/aws-controllers-k8s/elasticsearchservice-controller
 
 ## Amazon EC2 VPC
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/489
-* Current project stage: `PROPOSED`
+* Current project stage: `IN PROGRESS`
 * AWS service documentation: https://docs.aws.amazon.com/vpc/
+* ACK service controller: https://github.com/aws-controllers-k8s/ec2-controller
 
 ## AWS IAM
 
@@ -144,7 +143,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/238
 * Current project stage: `IN PROGRESS`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/10
 * AWS service documentation: https://aws.amazon.com/lambda/
 
 ## Amazon Kinesis
@@ -157,15 +155,14 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/491
 * Current project stage: `IN PROGRESS`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/18
 * AWS service documentation: https://aws.amazon.com/kms/
 * ACK service controller: https://github.com/aws-controllers-k8s/kms-controller
 
 ## Amazon MQ
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/390
-* Current project stage: `IN PROGRESS`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/12
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
 * AWS service documentation: https://aws.amazon.com/amazon-mq/
 * ACK service controller: https://github.com/aws-controllers-k8s/mq-controller
 
@@ -173,14 +170,13 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/348
 * Current project stage: `PLANNED`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/13
 * AWS service documentation: https://aws.amazon.com/msk/
 
 ## Amazon RDS
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/237
-* Current project stage: `PLANNED`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/8
+* Current project stage: `RELEASED`
+* Current maintenance phase: `PREVIEW`
 * AWS service documentation: https://aws.amazon.com/rds/
 
 ## Amazon Route53
@@ -203,7 +199,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/202
 * Current project stage: `RELEASED`
 * Current maintenance phase: `PREVIEW`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/17
 * AWS service documentation: https://aws.amazon.com/sns/
 * ACK service controller: https://github.com/aws-controllers-k8s/sns-controller
 
@@ -211,7 +206,6 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/205
 * Current project stage: `IN PROGRESS`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/6
 * AWS service documentation: https://aws.amazon.com/sqs/
 * ACK service controller: https://github.com/aws-controllers-k8s/sqs-controller
 
@@ -228,6 +222,5 @@ Controller Release Roadmap](https://github.com/aws-controllers-k8s/community/pro
 * Proposed: https://github.com/aws-controllers-k8s/community/issues/204
 * Current project stage: `RELEASED`
 * Current maintenance phase: `PREVIEW`
-* Next milestone: https://github.com/aws-controllers-k8s/community/milestone/16
 * AWS service documentation: https://aws.amazon.com/s3/
 * ACK service controller: https://github.com/aws-controllers-k8s/s3-controller

--- a/docs/contents/user-docs/install.md
+++ b/docs/contents/user-docs/install.md
@@ -2,6 +2,21 @@
 
 In the following we walk you through installing an ACK service controller.
 
+!!! note **IMPORTANT**
+    Individual ACK service controllers may be in different
+    maintenance phases and follow separate release cadences. Please read our
+    documentation about [project stages][proj-stages] and
+    [maintenance phases][maint-phases] fully, including how we
+    [release and version][rel-ver] our controllers. Controllers in a `PREVIEW`
+    maintenance phase have at least one container image and Helm chart released to
+    an ECR Public repository. However, be aware that controllers in a `PREVIEW`
+    maintenance phase may have significant and breaking changes introduced in a
+    future release.
+
+[proj-stages]: https://aws-controllers-k8s.github.io/community/releases/#project-stages
+[maint-phases]: https://aws-controllers-k8s.github.io/community/releases/#maintenance-phases
+[rel-ver]: https://aws-controllers-k8s.github.io/community/releases/#releases-and-versioning
+
 ## Docker images
 
 !!! note "No single ACK Docker image"
@@ -10,20 +25,31 @@ In the following we walk you through installing an ACK service controller.
     for a particular AWS API.
 
 Each ACK service controller is packaged into a separate container image,
-published on a [public ECR repository][controller-repo].
+published in a public ECR repository that corresponds to that ACK service
+controller.
 
-[controller-repo]: https://gallery.ecr.aws/aws-controllers-k8s/controller
+Controller images can be found in an ECR Public repository following the naming
+scheme `public.ecr.aws/aws-controllers-k8s/{SERVICE}-controller`. For example,
+you can find the Docker images for different releases of the RDS service
+controller for ACK in the `public.ecr.aws/aws-controllers-k8s/rds-controller`
+repository.
 
-Individual ACK service controllers are tagged with `$SERVICE-$VERSION` Docker
-image tags, allowing you to download/test specific ACK service controllers. For
-example, if you wanted to test the `v0.1.0` release image of the ACK service
-controller for S3, you would pull the
-`public.ecr.aws/aws-controllers-k8s/controller:s3-v0.1.0` image.
+There is an ECR Public Gallery link for the controller image repository at a
+similarly-schemed link
+`https://gallery.ecr.aws/aws-controllers-k8s/$SERVICE-controller`. For
+instance, to view the available Docker image releases of the RDS service
+controller for ACK, visit
+[https://gallery.ecr.aws/aws-controllers-k8s/rds-controller][rds-ecr-gallery].
+
+[rds-ecr-gallery]: https://gallery.ecr.aws/aws-controllers-k8s/rds-controller
+
+Individual ACK service controllers are tagged with a Semantic Version release
+tag, for example `v0.5.0`.
 
 !!! note "No 'latest' tag"
     It is [not good practice][no-latest-tag] to rely on a `:latest` default
     image tag. There are actually no images tagged with a `:latest` tag in our
-    image repositories. You should always specify a `$SERVICE-$VERSION` tag
+    image repositories. You should always specify a Semantic Version tag
     when referencing an ACK service controller image.
 
 [no-latest-tag]: https://vsupalov.com/docker-latest-tag/
@@ -40,12 +66,21 @@ Each ACK service controller has a separate Helm chart that installs—as a
 Kubernetes `Deployment`—the ACK service controller, necessary custom resource
 definitions (CRDs), Kubernetes RBAC manifests, and other supporting artifacts.
 
-To view the Helm charts available for installation, check the ECR public
-repository for the [ACK Helm charts][charts-repo]. Click on the "Image tags"
-tab and take a note of the Helm chart tag for the service controller and
-version you wish to install.
+There is a separate ECR Public repository that contains the Helm charts for a
+specific ACK service controller. The ECR Public repository for Helm charts
+follows the naming scheme `public.ecr.aws/aws-controllers-k8s/$SERVICE-chart`.
+For example, you can find the Helm charts for different releases of the RDS
+service controller for ACK in the
+`public.ecr.aws/aws-controllers-k8s/rds-chart` repository.
 
-[charts-repo]: https://gallery.ecr.aws/aws-controllers-k8s/chart
+There is an ECR Public Gallery link for the Helm chart repository at a
+similarly-schemed link
+`https://gallery.ecr.aws/aws-controllers-k8s/$SERVICE-chart`. For
+instance, to view the available Helm charts that install releases of the RDS service
+controller for ACK, visit
+[https://gallery.ecr.aws/aws-controllers-k8s/rds-chart][rds-chart-ecr-gallery].
+
+[rds-chart-ecr-gallery]: https://gallery.ecr.aws/aws-controllers-k8s/rds-chart
 
 Before installing a Helm chart, you must first make the Helm chart available on
 the deployment host. To do so, use the `helm chart pull` and `helm chart
@@ -56,8 +91,8 @@ export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=s3
 export RELEASE_VERSION=v0.0.1
 export CHART_EXPORT_PATH=/tmp/chart
-export CHART_REPO=public.ecr.aws/aws-controllers-k8s/chart
-export CHART_REF=$CHART_REPO:$SERVICE-$RELEASE_VERSION
+export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$SERVICE-chart
+export CHART_REF=$CHART_REPO:$RELEASE_VERSION
 
 mkdir -p $CHART_EXPORT_PATH
 
@@ -100,7 +135,7 @@ you should see your newly-deployed Helm chart release:
 ```
 $ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
 - app_version: v0.0.1
-  chart: ack-s3-controller-v0.0.1
+  chart: s3-controller
   name: ack-s3-controller
   namespace: ack-system
   revision: "1"
@@ -111,12 +146,24 @@ $ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
 ## Static Kubernetes manifests
 
 If you prefer not to use Helm, you may install a service controller using
-static Kubernetes manifests.
+static Kubernetes manifests that are included in the source repository for an
+ACK service controller.
 
-Static Kubernetes manifests that install individual service controllers are
-attached as artifacts to releases of AWS Controllers for Kubernetes. Select a
-release from the [list of releases][1] for AWS Controllers for Kubernetes.
+Static Kubernetes manifests that install the individual service controller as a
+Kubernetes `Deployment`, along with the relevant Kubernetes RBAC resources are
+available in the `config/` directory of the associated ACK service controller's
+source repository.
 
-[1]: https://github.com/aws/aws-controllers-k8s/releases
+For example, for the static manifests that will install the RDS service
+controller for ACK, check out the [`config/`][rds-config-dir] directory of the
+[RDS controller's source repo][rds-repo].
 
-TODO(jaypipes)
+[rds-config-dir]: https://github.com/aws-controllers-k8s/rds-controller/tree/main/config
+[rds-repo]: https://github.com/aws-controllers-k8s/rds-controller
+
+## Next Steps
+
+Once finished installing an ACK service controller, read about how
+[Authorization and Access Control][authorization] works.
+
+[authorization]: https://aws-controllers-k8s.github.io/community/user-docs/authorization/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,9 +10,9 @@ nav:
   - Overview: 'index.md'
   - Services: 'services.md'
 - User docs:
-  - Install: 'user-docs/wip.md'
-  - Permissions: 'user-docs/wip.md'
-  - Usage: 'user-docs/wip.md'
+  - Install: 'user-docs/install.md'
+  - Authorization and Access Control: 'user-docs/authorization.md'
+  - IAM Roles for Service Accounts: 'user-docs/irsa.md'
 - Contributor docs:
   - Overview: 'dev-docs/overview.md'
   - Code generation: 'dev-docs/code-generation.md'
@@ -27,8 +27,8 @@ nav:
   - Background: 'community/background.md'
   - FAQ: 'community/faq.md'
   - Discussions: 'community/discussions.md'
-  - Contributing: 'https://github.com/aws/aws-controllers-k8s/blob/master/CONTRIBUTING.md'
-  - Governance: 'https://github.com/aws/aws-controllers-k8s/blob/master/GOVERNANCE.md'
+  - Contributing: 'https://github.com/aws-controllers-k8s/community/blob/master/CONTRIBUTING.md'
+  - Governance: 'https://github.com/aws-controllers-k8s/community/blob/master/GOVERNANCE.md'
 extra:
   social:
   - icon: 'fontawesome/brands/twitter'


### PR DESCRIPTION
Updates our documentation in order to have our new ECR Public
repositories exposed in appropriate links.

Removes the "Work in Progress" user documentation navigation and
adds our install, IRSA and Authorization user docs to the navigation
sidebar.

Updates the Services matrix with the most up-to-date links and statuses.

Finally, replaces the wording in the documentation index/homepage about
"Developer Preview" and "Not to use in production" with explanation
about our release process and maintenance phases and links to the
install docs.

Issue #829 

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
