### PR TITLE
Update Go version to `1.15`

### DIFF
--- a/docs/contents/dev-docs/setup.md
+++ b/docs/contents/dev-docs/setup.md
@@ -18,7 +18,7 @@ Please ensure that you have [properly installed Go][install-go].
 [install-go]: https://golang.org/doc/install
 
 !!! note "Go version"
-    We recommend to use a Go version of `1.14` or above for development.
+    We recommend to use a Go version of `1.15` or above for development.
 
 ## Fork upstream repositories
 


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/925

Description of changes:
As a result of changing to ECR public, our base images now compile using Go 1.15. Updating the contributor setup document to reflect this.

We should probably try to upgrade all modules to require something like 1.17 when it's gained more traction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
