### PR TITLE
Update installation documentation for Helm 3.7 OCI

### DIFF
--- a/docs/content/docs/community/faq.md
+++ b/docs/content/docs/community/faq.md
@@ -70,8 +70,7 @@ Why am I seeing `Error: manifest does not contain minimum number of descriptors 
 {{% /hint %}}
 
 {{% hint type="answer" title="Answer" %}}
-[Helm 3.7](https://github.com/helm/helm/releases/tag/v3.7.0) included backward compatibility breaking changes to the manifest format of Helm charts stored in OCI chart repositories. Any images built using Helm <3.7 are not compatible with the latest version of the Helm CLI. This can be solved by using latest version of the chart.
-Also remember to use Helm with version 3.7 or above with latest version of chart.
+[Helm 3.7](https://github.com/helm/helm/releases/tag/v3.7.0) included backward compatibility breaking changes to the manifest format of Helm charts stored in OCI chart repositories. Any images built using Helm <3.7 are not compatible with the latest version of the Helm CLI. This can be solved by using latest version of the chart. Use Helm version 3.7 or above with the latest version of the charts.
 {{% /hint %}}
 
 ## Contributing

--- a/docs/content/docs/community/faq.md
+++ b/docs/content/docs/community/faq.md
@@ -63,6 +63,16 @@ The two projects complement each other.
 cdk8s can create the Kubernetes resources and ACK uses those resources to create the AWS infrastructure.
 {{% /hint %}}
 
+## Troubleshooting
+
+{{% hint type="success" title="Question" %}}
+Why am I seeing `Error: manifest does not contain minimum number of descriptors (2), descriptors found: 1` when trying to install the Helm chart?
+{{% /hint %}}
+
+{{% hint type="answer" title="Answer" %}}
+[Helm 3.7](https://github.com/helm/helm/releases/tag/v3.7.0) included backward compatibility breaking changes to the manifest format of Helm charts stored in OCI chart repositories. Any images built using Helm <3.7 are not compatible with the latest version of the Helm CLI. This can be solved by using to the latest version of the chart.
+{{% /hint %}}
+
 ## Contributing
 
 {{% hint type="success" title="Question" %}}

--- a/docs/content/docs/community/faq.md
+++ b/docs/content/docs/community/faq.md
@@ -70,7 +70,8 @@ Why am I seeing `Error: manifest does not contain minimum number of descriptors 
 {{% /hint %}}
 
 {{% hint type="answer" title="Answer" %}}
-[Helm 3.7](https://github.com/helm/helm/releases/tag/v3.7.0) included backward compatibility breaking changes to the manifest format of Helm charts stored in OCI chart repositories. Any images built using Helm <3.7 are not compatible with the latest version of the Helm CLI. This can be solved by using to the latest version of the chart.
+[Helm 3.7](https://github.com/helm/helm/releases/tag/v3.7.0) included backward compatibility breaking changes to the manifest format of Helm charts stored in OCI chart repositories. Any images built using Helm <3.7 are not compatible with the latest version of the Helm CLI. This can be solved by using latest version of the chart.
+Also remember to use Helm with version 3.7 or above with latest version of chart.
 {{% /hint %}}
 
 ## Contributing

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -31,7 +31,7 @@ This guide assumes that you have:
     - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
 
 {{% hint type="warning" title="Use the correct Helm version" %}}
-Helm 3.7 introduced breaking changes to this tutorial. Be sure to install a Helm version that is greater than 3.0 and less than 3.7.
+Helm 3.7 introduced breaking changes to this tutorial. Be sure to install a Helm version that is greater than or equal to 3.7.
 {{% /hint %}}
 
 ### Configure IAM permissions

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -28,7 +28,7 @@ This guide assumes that you have:
     - [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) - A command line tool for working with Kubernetes clusters. 
     - [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) - A command line tool for working with EKS clusters.
     - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [`wget` plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
-    - [Helm](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
+    - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
 
 {{% hint type="warning" title="Use the correct Helm version" %}}
 Helm 3.7 introduced breaking changes to this tutorial. Be sure to install a Helm version that is greater than 3.0 and less than 3.7.
@@ -116,14 +116,15 @@ export SERVICE=sagemaker
 export LATEST_RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/sagemaker-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
 export RELEASE_VERSION=${LATEST_RELEASE_VERSION:-v0.0.4}
 export CHART_EXPORT_PATH=/tmp/chart
-export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$SERVICE-chart
-export CHART_REF=$CHART_REPO:$RELEASE_VERSION
+export CHART_REF=$SERVICE-chart
+export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF
+export CHART_PACKAGE=$CHART_REF-$RELEASE_VERSION.tgz
 export ACK_K8S_NAMESPACE=ack-system
 
 mkdir -p $CHART_EXPORT_PATH
-helm chart pull $CHART_REF
-helm chart list
-helm chart export $CHART_REF --destination $CHART_EXPORT_PATH
+
+helm pull oci://$CHART_REPO --version $RELEASE_VERSION -d $CHART_EXPORT_PATH
+tar xvf $CHART_EXPORT_PATH/$CHART_PACKAGE -C $CHART_EXPORT_PATH
 ```
 
 Update the Helm chart values for a cluster-scoped installation. 

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -28,7 +28,7 @@ Check the [project stage](../../community/releases/#project-stages) and [mainten
 The recommended way to install an ACK service controller for Kubernetes is to use [Helm 3.7+][helm-3-install].
 
 {{% hint type="warning" title="Use the correct Helm version" %}}
-Helm 3.7 introduced breaking changes to this installation guide. Be sure to install a Helm version that is greater than 3.0 and less than 3.7.
+Helm 3.7 introduced breaking changes to this installation guide. Be sure to install a Helm version that is greater than or equal to 3.7.
 {{% /hint %}}
 
 [helm-3-install]: https://helm.sh/docs/intro/install/

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -25,7 +25,7 @@ Check the [project stage](../../community/releases/#project-stages) and [mainten
 
 ## Install an ACK service controller with Helm (Recommended)
 
-The recommended way to install an ACK service controller for Kubernetes is to use [Helm 3][helm-3-install].
+The recommended way to install an ACK service controller for Kubernetes is to use [Helm 3.7+][helm-3-install].
 
 {{% hint type="warning" title="Use the correct Helm version" %}}
 Helm 3.7 introduced breaking changes to this installation guide. Be sure to install a Helm version that is greater than 3.0 and less than 3.7.
@@ -42,20 +42,21 @@ Helm charts for individual ACK service controllers are tagged with their release
 [ack-ecr-gallery]: https://gallery.ecr.aws/aws-controllers-k8s
 [s3-ecr-chart]: https://gallery.ecr.aws/aws-controllers-k8s/s3-chart
 
-Before installing a Helm chart, you must first make the Helm chart available on the `Deployment` host. To do so, use the `helm chart pull` and `helm chart export` commands:
+Before installing a Helm chart, you must first make the Helm chart available on the `Deployment` host. To do so, use the `helm pull` command and then extract the chart:
 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=s3
 export RELEASE_VERSION=v0.0.1
 export CHART_EXPORT_PATH=/tmp/chart
-export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$SERVICE-chart
-export CHART_REF=$CHART_REPO:$RELEASE_VERSION
+export CHART_REF=$SERVICE-chart
+export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF
+export CHART_PACKAGE=$CHART_REF-$RELEASE_VERSION.tgz
 
 mkdir -p $CHART_EXPORT_PATH
 
-helm chart pull $CHART_REF
-helm chart export $CHART_REF --destination $CHART_EXPORT_PATH
+helm pull oci://$CHART_REPO --version $RELEASE_VERSION -d $CHART_EXPORT_PATH
+tar xvf $CHART_EXPORT_PATH/$CHART_PACKAGE -C $CHART_EXPORT_PATH
 ```
 
 Once the Helm chart is downloaded and exported, you can install a particular ACK service controller using the `helm install` command:
@@ -64,14 +65,14 @@ Once the Helm chart is downloaded and exported, you can install a particular ACK
 export ACK_K8S_NAMESPACE=ack-system
 
 helm install --create-namespace --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller \
-    $CHART_EXPORT_PATH/ack-$SERVICE-controller
+    $CHART_EXPORT_PATH/$SERVICE-chart
 ```
 
 The `helm install` command should return relevant installation information:
 
 ```bash
-helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller $CHART_EXPORT_PATH/ack-$SERVICE-controller
-NAME: ack-s3-controller
+helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller $CHART_EXPORT_PATH/$SERVICE-chart
+NAME: s3-chart
 LAST DEPLOYED: Thu Dec 17 13:09:17 2020
 NAMESPACE: ack-system
 STATUS: deployed


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/969

Description of changes:
Update any reference to Helm in the installation documentation, removing references to the deprecated OCI chart Helm CLI verbs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
