### PR TITLE
Keep installation docs up-to-date with latest s3-controller version

### DIFF
--- a/docs/content/docs/user-docs/authorization.md
+++ b/docs/content/docs/user-docs/authorization.md
@@ -3,14 +3,14 @@ title: "Configure Permissions"
 description: "Configuring RBAC and IAM for ACK"
 lead: "Set up RBAC and IAM for authorization and access"
 draft: false
-menu: 
+menu:
   docs:
     parent: "installing"
 weight: 20
 toc: true
 ---
 
-There are two different Role-Based Access Control (RBAC) systems needed for ACK service controller authorization: Kubernetes RBAC and AWS IAM. 
+There are two different Role-Based Access Control (RBAC) systems needed for ACK service controller authorization: Kubernetes RBAC and AWS IAM.
 
 [Kubernetes RBAC][k8s-rbac] governs a Kubernetes user's ability to read or write Kubernetes resources, while [AWS Identity and Access Management][aws-iam] (IAM) policies govern the ability of an AWS IAM role to read or write AWS resources.
 
@@ -18,7 +18,10 @@ There are two different Role-Based Access Control (RBAC) systems needed for ACK 
 [aws-iam]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html
 
 {{% hint type="info" title="These two RBAC systems to not overlap" %}}
-The Kubernetes user that makes a Kubernetes API call with `kubectl` has no association with an IAM role. Instead, the IAM role is associated with the [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) that runs the ACK service controller's pod.
+The Kubernetes user that makes a Kubernetes API call with `kubectl` has no
+association with an IAM role. Instead, the IAM role is associated with the
+[service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+that runs the ACK service controller's pod.
 {{% /hint %}}
 
 Refer to the following diagram for more details on running a Kubernetes API server with RBAC authorization mode enabled.
@@ -26,6 +29,12 @@ Refer to the following diagram for more details on running a Kubernetes API serv
 ![Authorization in ACK](../images/authorization.png)
 
 You will need to configure Kubernetes RBAC and AWS IAM permissions before using ACK service controllers.
+
+{{% hint type="success" title="Note" %}}
+If you performed [controller installation](../install) using Helm or static manifests
+from the [previous guide](../install), then Kubernetes RBAC (`Step 1`) was already configured
+for you. Continue executing the commands from `Step 2` below to setup AWS permissions.
+{{% /hint %}}
 
 ## Step 1: Configure Kubernetes RBAC
 
@@ -44,7 +53,7 @@ For example, installing the ACK service controller for AWS S3 creates the `ack-s
 
 ### Bind a Kubernetes user to a Kubernetes role
 
-Once the Kubernetes `Role` resources have been created, you can assign a specific Kubernetes `User` to a particular `Role` with the `kubectl create rolebinding` command. 
+Once the Kubernetes `Role` resources have been created, you can assign a specific Kubernetes `User` to a particular `Role` with the `kubectl create rolebinding` command.
 
 ```bash
 kubectl create rolebinding alice-ack-s3-writer --role ack-s3-writer --namespace testing --user alice
@@ -58,7 +67,7 @@ kubectl auth can-i create buckets --namespace default
 
 ## Step 2: Configure AWS IAM
 
-After configuring Kubernetes RBAC permissions, you need to create the necessary AWS IAM roles and policies. 
+After configuring Kubernetes RBAC permissions, you need to create the necessary AWS IAM roles and policies.
 
 The IAM role needs the correct [IAM policies][aws-iam] for a given ACK service controller. For example, the ACK service controller for AWS S3 needs read and write permission for S3 Buckets. It is recommended that the IAM policy gives only enough access to properly manage the resources needed for a specific AWS service.
 
@@ -66,7 +75,7 @@ To use the recommended IAM policy for a given ACK service controller, refer to t
 
 [s3-recommended-arn]: https://github.com/aws-controllers-k8s/s3-controller/tree/main/config/iam
 
-Apply the IAM policy to the IAM role with the `aws iam attach-role-policy` command: 
+Apply the IAM policy to the IAM role with the `aws iam attach-role-policy` command:
 
 ```bash
 SERVICE=s3
@@ -78,7 +87,7 @@ aws iam attach-role-policy \
     --policy-arn $POLICY_ARN
 ```
 
-Some services may need an additional inline policy. For example, the service controller may require `iam:PassRole` permission in order to pass an execution role that will be assumed by the AWS service. If applicable, resources for additional recommended policies will be located in the `additional-policy` file within the `config/iam` folder of a given ACK service controller's public repository. You can apply this policy to an IAM role by replacing the `POLICY_URL` variable in the script above. 
+Some services may need an additional inline policy. For example, the service controller may require `iam:PassRole` permission in order to pass an execution role that will be assumed by the AWS service. If applicable, resources for additional recommended policies will be located in the `additional-policy` file within the `config/iam` folder of a given ACK service controller's public repository. You can apply this policy to an IAM role by replacing the `POLICY_URL` variable in the script above.
 
 If you have not yet created an IAM role, see the user documentation on how to [create an IAM role for your ACK service controller][irsa-docs].
 

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -3,7 +3,7 @@ title: "Installation"
 description: "Installing an ACK controller"
 lead: ""
 draft: false
-menu: 
+menu:
   docs:
     parent: "installing"
 weight: 10
@@ -12,7 +12,7 @@ toc: true
 
 The following guide will walk you through the installation of an [ACK service controller][ack-services].
 
-Individual ACK service controllers may be in different maintenance phases and follow separate release cadences. Please check the [project stages][proj-stages] and [maintenance phases][maint-phases] of the ACK service controllers you wish to install, including how controllers are [released and versioned][rel-ver]. Controllers in a preview maintenance phase have at least one container image and Helm chart released to a public repository. 
+Individual ACK service controllers may be in different maintenance phases and follow separate release cadences. Please check the [project stages][proj-stages] and [maintenance phases][maint-phases] of the ACK service controllers you wish to install, including how controllers are [released and versioned][rel-ver]. Controllers in a preview maintenance phase have at least one container image and Helm chart released to a public repository.
 
 {{% hint title="Be mindful of maintenance phases" %}}
 Check the [project stage](../../community/releases/#project-stages) and [maintenance phase](../../community/releases/#maintenance-phases) of the ACK service controller you wish to install. Be aware that controllers in a preview maintenance phase may have significant and breaking changes introduced in a future release.
@@ -47,7 +47,7 @@ Before installing a Helm chart, you must first make the Helm chart available on 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=s3
-export RELEASE_VERSION=v0.0.1
+export RELEASE_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/aws-controllers-k8s/s3-controller.git | tail -n 1 | cut -d'/' -f3)
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF
@@ -58,6 +58,11 @@ mkdir -p $CHART_EXPORT_PATH
 helm pull oci://$CHART_REPO --version $RELEASE_VERSION -d $CHART_EXPORT_PATH
 tar xvf $CHART_EXPORT_PATH/$CHART_PACKAGE -C $CHART_EXPORT_PATH
 ```
+
+{{% hint type="info" title="controller version" %}}
+Above commands will download the latest version of `s3-controller`. To select a
+different version, change `RELEASE_VERSION` variable and execute the commands again.
+{{% /hint %}}
 
 Once the Helm chart is downloaded and exported, you can install a particular ACK service controller using the `helm install` command:
 
@@ -101,7 +106,7 @@ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
 
 ## Install an ACK service controller with static Kubernetes manifests
 
-If you prefer not to use Helm, you may install an ACK service controller using static Kubernetes manifests that are included in the source repository. 
+If you prefer not to use Helm, you may install an ACK service controller using static Kubernetes manifests that are included in the source repository.
 
 Static Kubernetes manifests install an individual service controller as a Kubernetes `Deployment`, including the relevant Kubernetes RBAC resources. Static Kubernetes manifests are available in the `config/` directory of the associated ACK service controller's source repository.
 

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -47,7 +47,7 @@ Before installing a Helm chart, you must first make the Helm chart available on 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=s3
-export RELEASE_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/aws-controllers-k8s/s3-controller.git | tail -n 1 | cut -d'/' -f3)
+export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/s3-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -80,7 +80,11 @@ helm install --create-namespace --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-cont
 The `helm install` command should return relevant installation information:
 
 ```bash
-helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller --set aws.account_id="$AWS_ACCOUNT_ID" --set aws.region="$AWS_REGION" $CHART_EXPORT_PATH/$SERVICE-chart
+helm install --create-namespace --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller \
+    --set aws.account_id="$AWS_ACCOUNT_ID" \
+    --set aws.region="$AWS_REGION" \
+    $CHART_EXPORT_PATH/$SERVICE-chart
+
 NAME: s3-chart
 LAST DEPLOYED: Thu Dec 17 13:09:17 2020
 NAMESPACE: ack-system
@@ -115,9 +119,9 @@ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
 ```
 
 {{% hint type="important" title="NOTE" %}}
-s3-controller should be installed successfully now but it is not fully functional.
-ACK controller needs access to AWS IAM credentials to manage AWS resources. See
-[Next Steps](#Next-steps) for configuring AWS IAM credentials for ACK controller.
+The `s3-controller` should be installed successfully now, but it is NOT yet fully
+functional. ACK controller needs access to AWS IAM credentials to manage AWS resources.
+See [Next Steps](#Next-steps) for configuring AWS IAM credentials for ACK controller.
 {{% /hint %}}
 
 ## Install an ACK service controller with static Kubernetes manifests

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -59,7 +59,7 @@ helm pull oci://$CHART_REPO --version $RELEASE_VERSION -d $CHART_EXPORT_PATH
 tar xvf $CHART_EXPORT_PATH/$CHART_PACKAGE -C $CHART_EXPORT_PATH
 ```
 
-{{% hint type="info" title="controller version" %}}
+{{% hint type="info" title="s3-controller version" %}}
 Above commands will download the latest version of `s3-controller`. To select a
 different version, change `RELEASE_VERSION` variable and execute the commands again.
 {{% /hint %}}
@@ -68,15 +68,19 @@ Once the Helm chart is downloaded and exported, you can install a particular ACK
 
 ```bash
 export ACK_K8S_NAMESPACE=ack-system
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export AWS_REGION=us-west-2
 
 helm install --create-namespace --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller \
+    --set aws.account_id="$AWS_ACCOUNT_ID" \
+    --set aws.region="$AWS_REGION" \
     $CHART_EXPORT_PATH/$SERVICE-chart
 ```
 
 The `helm install` command should return relevant installation information:
 
 ```bash
-helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller $CHART_EXPORT_PATH/$SERVICE-chart
+helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller --set aws.account_id="$AWS_ACCOUNT_ID" --set aws.region="$AWS_REGION" $CHART_EXPORT_PATH/$SERVICE-chart
 NAME: s3-chart
 LAST DEPLOYED: Thu Dec 17 13:09:17 2020
 NAMESPACE: ack-system
@@ -84,6 +88,12 @@ STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 ```
+
+{{% hint type="info" title="AWS Region" %}}
+Above commands will setup `s3-controller` to use `us-west-2` as AWS region. To
+select a different AWS region, change `AWS_REGION` variable and execute the
+commands again.
+{{% /hint %}}
 
 To verify that the Helm chart was installed, use the `helm list` command:
 
@@ -95,7 +105,7 @@ The `helm list` command should return your newly-deployed Helm chart release inf
 
 ```bash
 helm list --namespace $ACK_K8S_NAMESPACE -o yaml
-- app_version: v0.0.1
+- app_version: v0.0.5
   chart: s3-controller
   name: ack-s3-controller
   namespace: ack-system

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -114,6 +114,12 @@ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
   updated: 2020-12-17 13:09:17.309002201 -0500 EST
 ```
 
+{{% hint type="important" title="NOTE" %}}
+s3-controller should be installed successfully now but it is not fully functional.
+ACK controller needs access to AWS IAM credentials to manage AWS resources. See
+[Next Steps](#Next-steps) for configuring AWS IAM credentials for ACK controller.
+{{% /hint %}}
+
 ## Install an ACK service controller with static Kubernetes manifests
 
 If you prefer not to use Helm, you may install an ACK service controller using static Kubernetes manifests that are included in the source repository.


### PR DESCRIPTION
Description of changes:
* use latest s3-controller release for getting-started guide
* This will encourage keeping the guide up-to-date
* there will be less surprises for beginner users when they move from `getting-started` to using latest controllers for their workload
* this will provide the beginner users most up-to-date behavior of ACK controller runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
