### PR TITLE
add project tenets to contrib docs

### DIFF
--- a/docs/content/docs/contributor-docs/code-organization.md
+++ b/docs/content/docs/contributor-docs/code-organization.md
@@ -1,0 +1,77 @@
+---
+title: "Code Organization"
+description: "How the source code for ACK is organized"
+lead: ""
+draft: false
+menu:
+  docs:
+    parent: "contributor"
+weight: 20
+toc: true
+---
+
+ACK is a collection of source repositories containing a common runtime and type
+system, a code generator and individual service controllers that manage
+resources in a specific AWS API.
+
+* [`github.com/aws-controllers-k8s/community`][comm-repo]: docs, issues and
+  project management (this repo)
+* [`github.com/aws-controllers-k8s/runtime`][rt-repo]: common ACK runtime and types
+* [`github.com/aws-controllers-k8s/code-generator`][codegen-repo]: the code generator and
+  templates
+* [`github.com/aws-controllers-k8s/test-infra`][testinfra-repo]: common test code and infrastructure
+* `github.com/aws-controllers-k8s/$SERVICE-controller`: individual ACK
+  controllers for AWS services.
+
+## `github.com/aws-controllers-k8s/community` (this repo)
+
+The [`github.com/aws-controllers-k8s/community`][comm-repo] source code
+repository (this repo) contains the documentation that gets published to
+https://aws-controllers-k8s.github.io/community/.
+
+{{% hint type="info" title="Bug reports and feature requests" %}}
+**NOTE**: All [bug reports and feature requests][issues] for all ACK source repositories
+are contained in this repository.
+{{% /hint %}}
+
+## `github.com/aws-controllers-k8s/runtime`
+
+The [`github.com/aws-controllers-k8s/runtime`][rt-repo] source code repository contains
+the common ACK controller runtime (`/pkg/runtime`, `/pkg/types`) and core
+public Kubernetes API types (`/apis/core`).
+
+## `github.com/aws-controllers-k8s/code-generator`
+
+The [`github.com/aws-controllers-k8s/code-generator`][codegen-repo] source code repository
+contains the `ack-generate` CLI tool (`/cmd/ack-generate`), the Go packages
+that are used in API inference and code generation (`/pkg/generate`,
+`/pkg/model`) and Bash scripts to build an ACK service controller
+(`/scripts/build-controller.sh`).
+
+## `github.com/aws-controllers-k8s/test-infra`
+
+The [`github.com/aws-controllers-k8s/test-infra`][testinfra-repo] source code repository
+contains the `acktest` Python package for common ACK e2e test code, the CDK to
+deploy our Prow CI/CD system and the scripts for running tests locally.
+
+## `github.com/aws-controllers-k8s/$SERVICE-controller`
+
+Each AWS API that has had a Kubernetes controller built to manage resources in
+that API has its own source code repository in the
+`github.com/aws-controllers-k8s` Github Organization. The source repos will be
+called `$SERVICE-controller`, for example the ACK service controller for S3 is
+located at [`github.com/aws-controllers-k8s/s3-controller`][s3-repo].
+
+These service controller repositories contain Go code for the main controller
+binary (`/cmd/controller/`), the public API types for the controllers
+(`/apis`), the Go code for the resource managers used by the controller
+(`/pkg/resource/*/`), static configuration manifests (`/config`), Helm
+charts for the controller installation (`/helm`) along with a set of end-to-end
+tests for the resources exposed by that controller (`/test/e2e`).
+
+[issues]: https://github.com/aws-controllers-k8s/community/issues
+[comm-repo]: https://github.com/aws-controllers-k8s/community/
+[rt-repo]: https://github.com/aws-controllers-k8s/runtime/
+[codegen-repo]: https://github.com/aws-controllers-k8s/code-generator/
+[testinfra-repo]: https://github.com/aws-controllers-k8s/test-infra/
+[s3-repo]: https://github.com/aws-controllers-k8s/s3-controller/

--- a/docs/content/docs/contributor-docs/overview.md
+++ b/docs/content/docs/contributor-docs/overview.md
@@ -10,7 +10,40 @@ weight: 10
 toc: true
 ---
 
-This section of the docs is for ACK contributors.
+This section of the docs is for contributors to the AWS Controllers for
+Kubernetes (ACK) project.
+
+If you're interested in enhancing our platform, developing on a specific
+service controller or just curious how ACK is architected, you've come to the
+right place.
+
+## Project Tenets (unless you know better ones)
+
+We follow a set of tenets in building AWS Controllers for Kubernetes.
+
+1. **Collaborate in the Open**: Our source code is open. Our development
+   methodology is open. Our testing, release and documentation processes are
+   open. We are a community-driven project that strives to meet our users where
+   they are.
+
+2. **Generate Everything**: We choose to generate as much of our code as
+   possible. Generated code is easier to maintain and encourages consistency.
+
+3. **Focus on Kubernetes**: We seek ways to make the Kubernetes user experience
+   as simple and consistent as possible for managing AWS resources.
+
+4. **Run Anywhere**: ACK service controllers can be installed on any Kubernetes
+   cluster, regardless of whether a user chooses to use Amazon Elastic
+   Kubernetes Service (EKS).
+
+5. **Minimize Service Dependencies**: The only AWS services that ACK service
+   controllers depend on should be IAM/STS and the specific AWS service that
+   the controller integrates with. We do not take a dependency on any stateful
+   resource-tracking service.
+
+Read more about our [project tenets and design principles][tenets].
+
+[tenets]: ../tenets/
 
 ## Code Organization
 
@@ -18,59 +51,16 @@ ACK is a collection of source repositories containing a common runtime and type
 system, a code generator and individual service controllers that manage
 resources in a specific AWS API.
 
-* `github.com/aws-controllers-k8s/community`: docs and project management (this repo)
-* `github.com/aws-controllers-k8s/runtime`: common ACK runtime and types
-* `github.com/aws-controllers-k8s/code-generator`: the code generator and
-  templates
-* `github.com/aws-controllers-k8s/test-infra`: common test code and infrastructure
-* `github.com/aws-controllers-k8s/$SERVICE-controller`: individual ACK
-  controllers for AWS services.
+Learn more about how our [source code repositories are organized][code-org].
 
-### `github.com/aws-controllers-k8s/community` (this repo)
-
-The `github.com/aws-controllers-k8s/community` source code repository (this
-repo) contains the documentation that gets published to
-https://aws-controllers-k8s.github.io/community/.
-
-### `github.com/aws-controllers-k8s/runtime`
-
-The `github.com/aws-controllers-k8s/runtime` source code repository contains
-the common ACK controller runtime (`/pkg/runtime`, `/pkg/types`) and core
-public Kubernetes API types (`/apis/core`).
-
-### `github.com/aws-controllers-k8s/code-generator`
-
-The `github.com/aws-controllers-k8s/code-generator` source code repository
-contains the `ack-generate` CLI tool (`/cmd/ack-generate`), the Go packages
-that are used in API inference and code generation (`/pkg/generate`,
-`/pkg/model`) and Bash scripts to build an ACK service controller
-(`/scripts/build-controller.sh`).
-
-### `github.com/aws-controllers-k8s/test-infra`
-
-The `github.com/aws-controllers-k8s/test-infra` source code repository
-contains the `acktest` Python package for common ACK e2e test code, the CDK to
-deploy our Prow CI/CD system and the scripts for running tests locally.
-
-### `github.com/aws-controllers-k8s/$SERVICE-controller`
-
-Each AWS API that has had a Kubernetes controller built to manage resources in
-that API has its own source code repository in the
-`github.com/aws-controllers-k8s` Github Organization. The source repos will be
-called `$SERVICE-controller`.
-
-These service controller repositories contain Go code for the main controller
-binary (`/cmd/controller/`), the public API types for the controllers
-(`/apis`), the Go code for the resource managers used by the controller
-(`/pkg/resource/*/`), static configuration manifests (`/config`) and Helm
-charts for the controller installation (`/helm`).
+[code-org]: ../code-organization/
 
 ## API Inference
 
 Read about [how the code generator infers][api-inference] information about a
 Kubernetes Custom Resource Definitions (CRDs) from an AWS API model file.
 
-[api-inference]: ../../contributor-docs/api-inference/
+[api-inference]: ../api-inference/
 
 ## Code Generation
 

--- a/docs/content/docs/contributor-docs/tenets.md
+++ b/docs/content/docs/contributor-docs/tenets.md
@@ -1,0 +1,85 @@
+---
+title: "Project Tenets"
+description: "Our project tenets and design principles"
+lead: ""
+draft: false
+menu:
+  docs:
+    parent: "contributor"
+weight: 15
+toc: true
+---
+
+We follow a set of tenets in building AWS Controllers for Kubernetes.
+
+## Collaborate in the Open
+
+When given a choice between keeping something hidden or making something open,
+we default to open.
+
+All of our [source code][source] is open.
+
+Our development methodology is open.
+
+Our [testing][testing], [release][release] and [documentation][docs] processes
+are open.
+
+Our [continuous integration system][ci] is open.
+
+We are a community-driven project that strives to meet our users where they
+are. Come join our [community meeting][comm-meet] on Zoom.
+
+[source]: https://github.com/aws-controllers-k8s/
+[testing]: https://github.com/aws-controllers-k8s/test-infra
+[release]: ../../community/releases/
+[docs]: https://github.com/aws-controllers-k8s/community/tree/main/docs
+[ci]: https://prow.ack.aws.dev/
+[comm-meet]: https://github.com/aws-controllers-k8s/community/#community-meeting
+
+## Generate Everything
+
+We choose to generate as much of our code as possible.
+
+While we recognize that the differences and peculiarities of AWS service APIs
+will naturally require some implementation code to be hand-written, we look for
+patterns in AWS service APIs and enhance our code generator to handle these
+patterns.
+
+Generated code is easier to maintain and encourages consistency.
+
+## Focus on Kubernetes
+
+The ACK code generator produces controller implementations that include a
+[common ACK runtime][rt]. This common runtime builds on top of the Kubernetes
+upstream [controller-runtime][ctrl-rt] framework and provides a common
+reconciliation loop that processes events receive from the Kubernetes API
+server representing create, modify or delete operations for a custom resource.
+By building ACK controllers with a common ACK runtime, we encourage consistent
+behaviour in how controllers handle these custom resources.
+
+We seek ways to make the **Kubernetes user experience** as simple and
+consistent as possible for managing AWS resources. This means that the ACK code
+generator enables service teams to rename fields for a resource, inject custom
+code into a controller and instruct the controller implementation to handle
+resources in ways that smooth over the inconsistencies between AWS service
+APIs.
+
+[rt]: https://github.com/aws-controllers-k8s/runtime
+[ctrl-rt]: https://github.com/kubernetes-sigs/controller-runtime/
+
+## Run Anywhere
+
+ACK service controllers can be installed on any Kubernetes cluster, regardless
+of whether a user chooses to use Amazon Elastic Kubernetes Service (EKS).
+
+## Minimize Service Dependencies
+
+The only AWS services that ACK service controllers depend on should be IAM/STS
+and the specific AWS service that the controller integrates with.
+
+We do not take a dependency on any stateful resource-tracking service,
+including AWS CloudFormation, the AWS Cloud Control API, or Terraform.
+
+ACK service controllers communicate directly with the AWS service API that the
+controller is built for. The `s3-controller` speaks the S3 API. The
+`ec2-controller` speaks the EC2 API.


### PR DESCRIPTION
Adds a new Project Tenets section to our contributor docs and splits out
the code organization section into its own sub-page.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
