### PR TITLE
Fix broken contributor docs link in FAQ

### DIFF
--- a/docs/content/docs/community/faq.md
+++ b/docs/content/docs/community/faq.md
@@ -81,5 +81,5 @@ Where and how can I help?
 
 {{% hint type="answer" title="Answer" %}}
 Excellent question and we're super excited that you're interested in ACK.
-For now, if you're a developer, you can check out the [contributor docs](../../dev-docs/overview/).
+For now, if you're a developer, you can check out the [contributor docs](../../contributor-docs/overview/).
 {{% /hint %}}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This just fixes a broken link I noticed on the FAQ page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
