### PR TITLE
Updated Application Auto Scaling pass role policy

### DIFF
--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -87,7 +87,13 @@ printf '{
 ' > ./trust.json
 ```
 
-Updating an Application Auto Scaling Scalable Target requires additional permissions. Create a file named `pass_role_policy.json` to create the policy required for the IAM role.
+Updating an Application Auto Scaling Scalable Target requires additional permissions. First, create a service-linked role for Application Auto Scaling.
+
+```sh
+ aws iam create-service-linked-role --aws-service-name sagemaker.application-autoscaling.amazonaws.com
+```
+
+Create a file named `pass_role_policy.json` to create the policy required for the IAM role.
 
 ```bash
 printf '{
@@ -96,7 +102,7 @@ printf '{
     {
       "Effect": "Allow",
       "Action": "iam:PassRole",
-      "Resource": "*"
+      "Resource": "arn:aws:iam::'$AWS_ACCOUNT_ID':role/aws-service-role/sagemaker.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_SageMakerEndpoint"
     }
   ]
 }


### PR DESCRIPTION
Small updates to the Application Auto Scaling permissions configuration in the stand-alone tutorial based on updates in the controller ReadMe (https://github.com/aws-controllers-k8s/sagemaker-controller/pull/130/commits/194bee023a1eb4af2af6a5ad175bf26e255df7ef)

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
