### PR TITLE
Fix example crossplane generation cmd

### DIFF
--- a/docs/content/docs/contributor-docs/code-generation.md
+++ b/docs/content/docs/contributor-docs/code-generation.md
@@ -124,7 +124,7 @@ services to be used in Crossplane AWS Provider. To try it out, you can run the
 following command:
 
 ```bash
-go run -tags codegen cmd/ack-generate/main.go crossplane apis ecr --provider-dir <directory for provider>
+go run -tags codegen cmd/ack-generate/main.go crossplane ecr --provider-dir <directory for provider>
 cd <directory for provider>
 go generate ./...
 ```


### PR DESCRIPTION
The crossplane cmd does not appear to have an "apis" sub-command (anymore?)