### PR TITLE
Generate runtime API reference documentation

### DIFF
--- a/docs/layouts/partials/sidebar/list-card.html
+++ b/docs/layouts/partials/sidebar/list-card.html
@@ -1,0 +1,12 @@
+<h2>{{ .service_metadata.service.short_name }}</h2>
+<div class="card my-3">
+    <ul class="list-group list-group-flush">
+        {{ $service := . }}
+        {{ range sort .resources "name" "asc" }}
+        <div class="list-group-item d-flex flex-row align-items-center">
+            <a class="stretched-link flex-fill" href="{{ printf "reference/%s/%s/%s/" $service.name .api_version .name | lower | relURL }}">{{ .name }}</a>
+            <small>{{ .api_version }}</small>
+        </div>
+        {{ end }}
+    </ul>
+</div>

--- a/docs/layouts/partials/sidebar/reference-menu-item.html
+++ b/docs/layouts/partials/sidebar/reference-menu-item.html
@@ -11,7 +11,7 @@
         {{ $api_version.api_version }}
       </button>
       {{ $versionAvailable := $api_version.status }}
-      <span class="badge bg-{{ if (eq $versionAvailable "available") }}success{{ else }}light{{ end }} position-absolute end-0">{{ if (eq $versionAvailable "available") }}Active{{ else }}Inactive{{ end }}</span>
+      <span class="badge bg-{{ if (eq $versionAvailable "available") }}success{{ else }}light{{ end }} fw-normal text-uppercase position-absolute end-0">{{ if (eq $versionAvailable "available") }}Active{{ else }}Inactive{{ end }}</span>
       <div class="collapse ms-2{{ if $versionActive }} show{{ end }}" id="section-{{ $root.service.name }}-{{ $api_version.api_version }}">
         <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
         {{ range $resource := sort $root.service.resources "name" "asc" -}}

--- a/docs/layouts/partials/sidebar/reference-menu-item.html
+++ b/docs/layouts/partials/sidebar/reference-menu-item.html
@@ -1,0 +1,27 @@
+{{ $root := . }}
+<li class="mb-1">
+  {{ $serviceActive := eq $root.currentService $root.service.name }}
+  <button class="btn btn-toggle align-items-center rounded {{ if not $serviceActive }} collapsed{{ end }}" data-bs-toggle="collapse" data-bs-target="#section-{{ .service.name }}" aria-expanded="{{ if not $root.serviceActive }} false{{ else }}true{{ end }}">
+    {{ $root.service.service_metadata.service.short_name }}
+  </button>
+  <div class="collapse position-relative{{ if $serviceActive }} show{{ end }}" id="section-{{ $root.service.name }}">
+    {{ range $api_version := sort $root.service.service_metadata.api_versions }}
+      {{ $versionActive := and $serviceActive (eq $root.currentVersion ($api_version.api_version | lower)) }}
+      <button class="btn btn-toggle align-items-center rounded ms-2 small{{ if not $versionActive }} collapsed{{ end }}" data-bs-toggle="collapse" data-bs-target="#section-{{ $root.service.name }}-{{ $api_version.api_version }}" aria-expanded="{{ if not $versionActive }} false{{ else }}true{{ end }}">
+        {{ $api_version.api_version }}
+      </button>
+      {{ $versionAvailable := $api_version.status }}
+      <span class="badge bg-{{ if (eq $versionAvailable "available") }}success{{ else }}light{{ end }} position-absolute end-0">{{ if (eq $versionAvailable "available") }}Active{{ else }}Inactive{{ end }}</span>
+      <div class="collapse ms-2{{ if $versionActive }} show{{ end }}" id="section-{{ $root.service.name }}-{{ $api_version.api_version }}">
+        <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+        {{ range $resource := sort $root.service.resources "name" "asc" -}}
+          {{ if eq $resource.api_version $api_version.api_version -}}
+            {{ $resourceActive := and $versionActive (eq $root.currentResource (.name | lower)) }}
+            <li><a class="docs-link rounded{{ if $resourceActive }} active{{ end }}" href="{{ printf "reference/%s/%s/%s/" $root.service.name .api_version .name | lower | relURL }}">{{ .name }}</a></li>
+          {{ end -}}
+        {{ end -}}
+        </ul>
+      </div>
+    {{ end -}}
+  </div>
+</li>

--- a/docs/layouts/partials/sidebar/reference-menu.html
+++ b/docs/layouts/partials/sidebar/reference-menu.html
@@ -1,35 +1,28 @@
-{{ if .Site.Params.options.collapsibleSidebar -}}
-  <ul class="list-unstyled collapsible-sidebar">
-  {{ $currentPage := . -}}
-  {{- $pageSplit := split .RelPermalink "/" -}}
-  {{ $currentService := cond (ge (len $pageSplit) 2) (index $pageSplit 2) "" }}
-  {{ $currentVersion := cond (ge (len $pageSplit) 3) (index $pageSplit 3) "" }}
-  {{ $currentResource := cond (ge (len $pageSplit) 4) (index $pageSplit 4) "" }}
-  {{ range $service := sort .Site.Data.overview.services "name" "asc" }}
-    <li class="mb-1">
-      {{ $serviceActive := eq $currentService $service.name }}
-      <button class="btn btn-toggle align-items-center rounded {{ if not $serviceActive }} collapsed{{ end }}" data-bs-toggle="collapse" data-bs-target="#section-{{ $service.name }}" aria-expanded="{{ if not $serviceActive }} false{{ else }}true{{ end }}">
-        {{ $service.service_metadata.service.short_name }}
-      </button>
-      <div class="collapse{{ if $serviceActive }} show{{ end }}" id="section-{{ $service.name }}">
-        {{ range $api_version := sort $service.service_metadata.api_versions }}
-          {{ $versionActive := and $serviceActive (eq $currentVersion ($api_version.api_version | lower)) }}
-          <button class="btn btn-toggle align-items-center rounded ms-2 small{{ if not $versionActive }} collapsed{{ end }}" data-bs-toggle="collapse" data-bs-target="#section-{{ $service.name }}-{{ $api_version.api_version }}" aria-expanded="{{ if not $versionActive }} false{{ else }}true{{ end }}">
-            {{ $api_version.api_version }}
-          </button>
-          <div class="collapse ms-2{{ if $versionActive }} show{{ end }}" id="section-{{ $service.name }}-{{ $api_version.api_version }}">
-            <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-            {{ range $resource := sort $service.resources "name" "asc" -}}
-              {{ if eq $resource.api_version $api_version.api_version -}}
-                {{ $resourceActive := and $versionActive (eq $currentResource (.name | lower)) }}
-                <li><a class="docs-link rounded{{ if $resourceActive }} active{{ end }}" href="{{ printf "reference/%s/%s/%s/" $service.name .api_version .name | lower | relURL }}">{{ .name }}</a></li>
-              {{ end -}}
+<div class="col-lg-5 col-xl-4 docs-sidebar">
+    <nav class="docs-links" aria-label="Main navigation">
+        {{ if .Site.Params.options.collapsibleSidebar -}}
+            <ul class="list-unstyled collapsible-sidebar">
+            {{ $currentPage := . -}}
+            {{- $pageSplit := split .RelPermalink "/" -}}
+            {{ $currentService := cond (ge (len $pageSplit) 2) (index $pageSplit 2) "" }}
+            {{ $currentVersion := cond (ge (len $pageSplit) 3) (index $pageSplit 3) "" }}
+            {{ $currentResource := cond (ge (len $pageSplit) 4) (index $pageSplit 4) "" }}
+            
+            <!-- Find common and place it first -->
+            {{ range $service := sort .Site.Data.overview.services "name" "asc" }}
+                {{ if eq (lower $service.service_metadata.service.short_name) "common" }}
+                    {{ partial "sidebar/reference-menu-item.html" (dict "currentService" $currentService "currentVersion" $currentVersion "currentResource" $currentResource "service" $service) }}
+                {{ end -}}
+            {{ end -}}    
+
+            <hr />
+
+            {{ range $service := sort .Site.Data.overview.services "name" "asc" }}
+                {{ if not (eq (lower $service.service_metadata.service.short_name) "common" ) }}
+                    {{ partial "sidebar/reference-menu-item.html" (dict "currentService" $currentService "currentVersion" $currentVersion "currentResource" $currentResource "service" $service) }}
+                {{ end -}}
             {{ end -}}
             </ul>
-          </div>
         {{ end -}}
-      </div>
-    </li>
-  {{ end -}}
-  </ul>
-{{ end -}}
+    </nav>
+</div>

--- a/docs/layouts/reference/list.html
+++ b/docs/layouts/reference/list.html
@@ -1,28 +1,22 @@
 {{ define "main" }}
 <div class="row justify-content-center">
-    <div class="col-lg-5 col-xl-4 docs-sidebar">
-        <nav class="docs-links" aria-label="Main navigation">
-            {{ partial "sidebar/reference-menu.html" . }}
-        </nav>
-    </div>
+    {{ partial "sidebar/reference-menu.html" .}}
     <div class="col-lg-11 col-xl-9 mx-xl-auto">
         <article>
             <h1 class="text">{{ .Title }}</h1>
             <div class="text">{{ .Content }}</div>
             <div class="card-list">
+                <!-- Find common and place it first -->
                 {{ range sort .Site.Data.overview.services "name" "asc" }}
-                    <h2>{{ .service_metadata.service.short_name }}</h2>
-                    <div class="card my-3">
-                        <ul class="list-group list-group-flush">
-                            {{ $service := . }}
-                            {{ range sort .resources "name" "asc" }}
-                            <div class="list-group-item d-flex flex-row align-items-center">
-                                <a class="stretched-link flex-fill" href="{{ printf "reference/%s/%s/%s/" $service.name .api_version .name | lower | relURL }}">{{ .name }}</a>
-                                <small>{{ .api_version }}</small>
-                            </div>
-                            {{ end }}
-                        </ul>
-                    </div>
+                    {{ if eq (lower .service_metadata.service.short_name) "common" }}
+                        {{ partial "sidebar/list-card" . }}
+                    {{ end -}}
+                {{ end }}
+
+                {{ range sort .Site.Data.overview.services "name" "asc" }}
+                    {{ if not (eq (lower .service_metadata.service.short_name) "common" ) }}
+                        {{ partial "sidebar/list-card" . }}
+                    {{ end -}}
                 {{ end }}
             </div>
             

--- a/docs/layouts/reference/list.html
+++ b/docs/layouts/reference/list.html
@@ -13,6 +13,8 @@
                     {{ end -}}
                 {{ end }}
 
+                <hr />
+
                 {{ range sort .Site.Data.overview.services "name" "asc" }}
                     {{ if not (eq (lower .service_metadata.service.short_name) "common" ) }}
                         {{ partial "sidebar/list-card" . }}

--- a/docs/layouts/reference/single.html
+++ b/docs/layouts/reference/single.html
@@ -1,10 +1,6 @@
 {{ define "main" }}
 	<div class="row flex-xl-nowrap">
-		<div class="col-lg-5 col-xl-4 docs-sidebar">
-			<nav class="docs-links" aria-label="Main navigation">
-				{{ partial "sidebar/reference-menu.html" . }}
-			</nav>
-		</div>
+		{{ partial "sidebar/reference-menu.html" .}}
 		{{ if ne .Params.toc false -}}
 		<nav class="docs-toc d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
 			{{ partial "sidebar/docs-toc.html" . }}

--- a/docs/scripts/gen_reference.py
+++ b/docs/scripts/gen_reference.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import os
+import sys
 
 import yaml
 import argparse
@@ -33,6 +34,7 @@ class Field:
 class Resource:
     name: str
     service: str
+    service_package: str
     group: str
     api_version: str
     description: str
@@ -116,7 +118,7 @@ def convert_field(name: str, property: Dict, required=False) -> Field:
         contains_description=contains_description
     )
 
-def convert_crd_to_resource(crd: Dict, service) -> Resource:
+def convert_crd_to_resource(crd: Dict, service: str, service_package: str = "") -> Resource:
     ver = crd['spec']['versions'][0]
     schema = ver['schema']['openAPIV3Schema']
     res_spec = []
@@ -144,6 +146,7 @@ def convert_crd_to_resource(crd: Dict, service) -> Resource:
     return Resource(
         name=crd['spec']['names']['kind'],
         service=service,
+        service_package=f"{service}-controller/apis" if service_package == "" else service_package,
         group=crd['spec']['group'],
         api_version=ver['name'],
         description=spec.get('description', ''),
@@ -155,16 +158,17 @@ def convert_crd_to_resource(crd: Dict, service) -> Resource:
 
 def write_service_pages(
     service: str,
-    metadata: ServiceMetadata,
     service_path: Path,
     page_output_path: Path,
+    service_package: str = "",
 ) -> List[ResourceOverview]:
     resources = []
 
     for crd_path in Path(service_path).rglob('*.yaml'):
         crd = load_yaml(crd_path)
 
-        resource = convert_crd_to_resource(crd, service)
+        resource = convert_crd_to_resource(crd, service, service_package)
+
         resources.append(ResourceOverview(name=resource.name,
             api_version=resource.api_version))
 
@@ -193,6 +197,27 @@ def load_metadata_config(metadata_config_path: Path) -> ServiceMetadata:
         api_versions.append(MetadataAPIVersion(**version))
     return ServiceMetadata(description, api_versions)
 
+def generate_runtime_resources(
+    src_parent: Path,
+) -> ServiceOverview:
+    runtime_repo = src_parent / "runtime"
+    if not runtime_repo.is_dir():
+        logging.error(f"Could not find the runtime repository")
+        return 1
+
+    runtime_bases_path = runtime_repo / bases_path
+    if not runtime_bases_path.is_dir():
+        logging.error(f"Runtime base path {runtime_bases_path} does not exist")
+        return 1
+
+    runtime_resources = write_service_pages("Common", runtime_bases_path, page_output_path, "runtime/apis/core")
+    runtime_metadata = ServiceMetadata(
+        MetadataServiceDescription("ACK Common", "Common", "", ""),
+        [MetadataAPIVersion("v1alpha1", "available")]
+    )
+    runtime_overview = ServiceOverview("common", runtime_resources, runtime_metadata)
+    return runtime_overview
+
 def main(
     gopath: Path,
     metadata_config_path: Path,
@@ -201,9 +226,11 @@ def main(
     page_output_path: Path,
     data_output_path: Path
 ):
-    overviews = []
+    overviews: List[ServiceOverview] = []
 
     src_parent = gopath / go_src_parent
+
+    overviews.append(generate_runtime_resources(src_parent))
 
     for controller_repo in src_parent.glob("*-controller"):
         if not controller_repo.is_dir() or \
@@ -226,12 +253,13 @@ def main(
 
         metadata = load_metadata_config(metadata_config)
 
-        resources = write_service_pages(service, metadata, service_bases_path, page_output_path)
+        resources = write_service_pages(service, service_bases_path, page_output_path)
         overview = ServiceOverview(service, resources, metadata)
 
         overviews.append(overview)
 
     write_overview_page(overviews, data_output_path)
+    return 0
 
 
 if __name__ == "__main__":
@@ -258,4 +286,5 @@ if __name__ == "__main__":
     page_output_path = Path(args.page_output_path)
     data_output_path = Path(args.data_output_path)
 
-    main(gopath, metadata_config_path, go_src_parent, bases_path, page_output_path, data_output_path)
+    ret = main(gopath, metadata_config_path, go_src_parent, bases_path, page_output_path, data_output_path)
+    sys.exit(ret)

--- a/docs/scripts/templates/resource.jinja2
+++ b/docs/scripts/templates/resource.jinja2
@@ -7,7 +7,7 @@ toc: true
 `{{ group }}/{{ api_version }}`
 Type|Link
 ----|----
-GoDoc|[{{ service }}-controller/apis/{{ api_version }}#{{ names.kind }}](https://pkg.go.dev/github.com/aws-controllers-k8s/{{ service }}-controller/apis/{{ api_version }}#{{ names.kind }})
+GoDoc|[{{ service_package }}/{{ api_version }}#{{ names.kind }}](https://pkg.go.dev/github.com/aws-controllers-k8s/{{ service_package }}/{{ api_version }}#{{ names.kind }})
 
 ## Metadata
 Property|Value

--- a/docs/scripts/templates/resource.jinja2
+++ b/docs/scripts/templates/resource.jinja2
@@ -7,7 +7,7 @@ toc: true
 `{{ group }}/{{ api_version }}`
 Type|Link
 ----|----
-GoDoc|[{{ service_package }}/{{ api_version }}#{{ names.kind }}](https://pkg.go.dev/github.com/aws-controllers-k8s/{{ service_package }}/{{ api_version }}#{{ names.kind }})
+GoDoc|[{{ crd_package_path }}/{{ api_version }}#{{ names.kind }}](https://pkg.go.dev/github.com/aws-controllers-k8s/{{ crd_package_path }}/{{ api_version }}#{{ names.kind }})
 
 ## Metadata
 Property|Value


### PR DESCRIPTION
Description of changes:
Updates the API reference generator script to support the APIs defined in the `runtime` repository. Also updates the HTML of the API reference page to place the APIs in their own section at the top under `Common`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
