### PR TITLE
Bump version in RDS example

### DIFF
--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -42,13 +42,13 @@ This guide assumes that you have:
 You can deploy the ACK service controller for Amazon RDS using the [rds-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/rds-chart). You can download it to your workspace using the following command:
 
 ```bash
-helm pull oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.17
+helm pull oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.20
 ````
 
 You will need to decompress and extract the Helm chart. You can do so with the following command:
 
 ```bash
-tar xzvf rds-chart-v0.0.17.tgz
+tar xzvf rds-chart-v0.0.20.tgz
 ```
 
 You can now use the Helm chart to deploy the ACK service controller for Amazon RDS to your EKS cluster. At a minimum, you need to specify the AWS Region to execute the RDS API calls.


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This moves the Helm chart installation from v0.0.17 to v0.0.20 to utilize the FieldExport functionality.

I realize that we need a better solution instead of manually bumping each time. Here are two options:

1. Proposed by @RedbackThomson, we apply the `curl` method from a previous examples, i.e.

```diff
diff --git a/docs/content/docs/tutorials/rds-example.md b/docs/content/docs/tutorials/rds-example.md
index cf3e376f..6ddc868e 100644
--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -42,13 +42,14 @@ This guide assumes that you have:
 You can deploy the ACK service controller for Amazon RDS using the [rds-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/rds-chart). You can download it to your workspace using the following command:
 
 ```bash
-helm pull oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.17
+RDS_CHART_VERSION=$(curl -s https://api.github.com/repos/aws-controllers-k8s/rds-controller/releases/latest | awk -F\" '/tag_name/{print $(NF-1)}')
+helm pull oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version="${RDS_CHART_VERSION}"
 ````
 
 You will need to decompress and extract the Helm chart. You can do so with the following command:
 
 ```bash
-tar xzvf rds-chart-v0.0.17.tgz
+tar xzvf "rds-chart-${RDS_CHART_VERSION}.tgz"
 ```
 
 You can now use the Helm chart to deploy the ACK service controller for Amazon RDS to your EKS cluster. At a minimum, you need to specify the AWS Region to execute the RDS API calls.

While convenient for project maintainers and always ensuring users are loading the latest Helm chart, this does create an extra step for ACK users, i.e. running `curl` and storing the value in an environmental variable.

2. We use build automation to inject the updated value. I believe @jaypipes may have done some research in this area. While this places less burden on the user and makes the Helm chart version more visible, the documentation reader may not be aware of the latest Helm chart for the RDS controller until the docs are rebuilt and published.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
