### PR TITLE
Updating the path for the Helm Chart

### DIFF
--- a/docs/content/docs/user-docs/cleanup.md
+++ b/docs/content/docs/user-docs/cleanup.md
@@ -30,7 +30,7 @@ export SERVICE=s3
 export CHART_EXPORT_PATH=/tmp/chart
 
 # Delete an individual CRD
-kubectl delete -f $CHART_EXPORT_PATH/ack-$SERVICE-controller/crds/s3.services.k8s.aws_buckets.yaml
+kubectl delete -f $CHART_EXPORT_PATH/$SERVICE-chart/crds/s3.services.k8s.aws_buckets.yaml
 ```
 
 {{% hint type="warning" title="Check for CRDs that are common across services" %}}
@@ -45,7 +45,7 @@ export SERVICE=s3
 export CHART_EXPORT_PATH=/tmp/chart
 
 # Delete all CRDs
-kubectl delete -f $CHART_EXPORT_PATH/ack-$SERVICE-controller/crds
+kubectl delete -f $CHART_EXPORT_PATH/$SERVICE-chart/crds
 ```
 
 ## Verify Helm charts were deleted


### PR DESCRIPTION
Description of changes:

When installing the ACK Resource Helm Chart there is an environment variable set as CHART_REF=$SERVICE-chart. This creates the folder under /tmp/chart as $SERVICE-CHART. The path in the commands for deleting the CRDs doesn't exist because of that. 

I've updated the page with the right path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
