### PR TITLE
Upgrade install instructions to Helm 3.8

### DIFF
--- a/docs/content/docs/tutorials/apigatewayv2-reference-example.md
+++ b/docs/content/docs/tutorials/apigatewayv2-reference-example.md
@@ -38,28 +38,19 @@ This guide assumes that you have:
   - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html) - A command line tool for interacting with AWS services.
   - [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) - A command line tool for working with Kubernetes clusters.
   - [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) - A command line tool for working with EKS clusters.
-  - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
+  - [Helm 3.8+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
 
 ### Install the ACK service controller for APIGatewayv2
 
-Deploy the ACK service controller for Amazon APIGatewayv2 using the [apigatewayv2-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/apigatewayv2-chart).
-Download it to your workspace using the following command:
-
+Log into the Helm registry that stores the ACK charts:
 ```bash
-helm pull oci://public.ecr.aws/aws-controllers-k8s/apigatewayv2-chart --version=v0.0.17
-````
-
-Use the following command to decompress and extract the Helm chart:
-
-```bash
-tar xzvf apigatewayv2-chart-v0.0.17.tgz
+aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
 ```
 
-Deploy the controller using Helm chart, specifying that APIGatewayv2 resources should be created by default in the
-`us-east-1` region:
+Deploy the ACK service controller for Amazon APIGatewayv2 using the [apigatewayv2-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/apigatewayv2-chart). Resources should be created in the `us-east-1` region:
 
 ```bash
-helm install apigatewayv2-chart --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/apigatewayv2-chart --version=v0.0.17 --generate-name --set=aws.region=us-east-1
 ```
 
 For a full list of available values to the Helm chart, please [review the values.yaml file](https://github.com/aws-controllers-k8s/apigatewayv2-controller/blob/main/helm/values.yaml).

--- a/docs/content/docs/tutorials/memorydb-example.md
+++ b/docs/content/docs/tutorials/memorydb-example.md
@@ -30,28 +30,23 @@ This guide assumes that you have:
   - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html) - A command line tool for interacting with AWS services.
   - [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) - A command line tool for working with Kubernetes clusters.
   - [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) - A command line tool for working with EKS clusters.
-  - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
+  - [Helm 3.8+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
 
 ### Install the ACK service controller for Amazon MemoryDB
 
-You can deploy the ACK service controller for Amazon MemoryDB using the [memorydb-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/memorydb-chart). You can download it to your workspace using the following command:
+You can deploy the ACK service controller for Amazon MemoryDB using the [memorydb-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/memorydb-chart).
 
+Log into the Helm registry that stores the ACK charts:
 ```bash
-helm pull oci://public.ecr.aws/aws-controllers-k8s/memorydb-chart --version=v0.0.1
-````
-
-You will need to decompress and extract the Helm chart. You can do so with the following command:
-
-```bash
-tar xzvf memorydb-chart-v0.0.1.tgz
+aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
 ```
 
-You can now use the Helm chart to deploy the ACK service controller for Amazon MemoryDB to your EKS cluster. At a minimum, you need to specify the AWS Region to execute the Amazon MemoryDB API calls.
+You can install the Helm chart to deploy the ACK service controller for Amazon MemoryDB to your EKS cluster. At a minimum, you need to specify the AWS Region to execute the Amazon MemoryDB API calls.
 
 For example, to specify that the Amazon MemoryDB API calls go to the `us-east-1` region, you can deploy the service controller with the following command:
 
 ```bash
-helm install memorydb-chart --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/memorydb-chart --version=v0.0.1 --generate-name --set=aws.region=us-east-1
 ```
 
 For a full list of available values to the Helm chart, please [review the values.yaml file](https://github.com/aws-controllers-k8s/memorydb-controller/blob/main/helm/values.yaml).

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -39,16 +39,11 @@ This guide assumes that you have:
 
 ### Install the ACK service controller for RDS
 
-You can deploy the ACK service controller for Amazon RDS using the [rds-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/rds-chart). You can download it to your workspace using the following command:
+You can deploy the ACK service controller for Amazon RDS using the [rds-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/rds-chart).
 
+Log into the Helm registry that stores the ACK charts:
 ```bash
-helm pull oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.24
-````
-
-You will need to decompress and extract the Helm chart. You can do so with the following command:
-
-```bash
-tar xzvf rds-chart-v0.0.24.tgz
+aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
 ```
 
 You can now use the Helm chart to deploy the ACK service controller for Amazon RDS to your EKS cluster. At a minimum, you need to specify the AWS Region to execute the RDS API calls.
@@ -56,7 +51,7 @@ You can now use the Helm chart to deploy the ACK service controller for Amazon R
 For example, to specify that the RDS API calls go to the `us-east-1` region, you can deploy the service controller with the following command:
 
 ```bash
-helm install rds-chart --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.24 --generate-name --set=aws.region=us-east-1
 ```
 
 For a full list of available values to the Helm chart, please [review the values.yaml file](https://github.com/aws-controllers-k8s/rds-controller/blob/main/helm/values.yaml).


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1347

Description of changes:
Update the default instructions to use the newest support for OCI registries in Helm 3.8. Also updated most of the tutorials, which copied the same formula. I left ApplicationAutoscaling and SageMaker, as they handle values differently. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
