### PR TITLE
updating OpenShift and IRSA docs to explain IRSA support in OpenShift

### DIFF
--- a/docs/content/docs/user-docs/irsa.md
+++ b/docs/content/docs/user-docs/irsa.md
@@ -67,6 +67,14 @@ For detailed instructions, refer to Amazon EKS documentation on how to [create a
 
 ## Step 2. Create an IAM role and policy for your service account
 
+{{% hint type="info" title="Note" %}}
+If you're trying to set up IRSA on OpenShift replace the `OIDC_PROVIDER` line in the bash script below with the following command:
+
+```shell
+OIDC_PROVIDER=$(oc get authentication cluster -ojson | jq -r .spec.serviceAccountIssuer | sed -e "s/^https:\/\///")
+```
+{{% /hint %}}
+
 ### Create an IAM role for your ACK service controller
 ```bash
 # Update the service name variables as needed
@@ -99,7 +107,7 @@ EOF
 echo "${TRUST_RELATIONSHIP}" > trust.json
 
 ACK_CONTROLLER_IAM_ROLE="ack-${SERVICE}-controller"
-ACK_CONTROLLER_IAM_ROLE_DESCRIPTION='IRSA role for ACK $SERVICE controller deployment on EKS cluster using Helm charts'
+ACK_CONTROLLER_IAM_ROLE_DESCRIPTION="IRSA role for ACK ${SERVICE} controller deployment on EKS cluster using Helm charts"
 aws iam create-role --role-name "${ACK_CONTROLLER_IAM_ROLE}" --assume-role-policy-document file://trust.json --description "${ACK_CONTROLLER_IAM_ROLE_DESCRIPTION}"
 ACK_CONTROLLER_IAM_ROLE_ARN=$(aws iam get-role --role-name=$ACK_CONTROLLER_IAM_ROLE --query Role.Arn --output text)
 ```

--- a/docs/content/docs/user-docs/openshift.md
+++ b/docs/content/docs/user-docs/openshift.md
@@ -16,7 +16,7 @@ Configuration for ACK controllers in an OpenShift cluster.
 
 When ACK service controllers are installed via OperatorHub, a cluster administrator will need to perform the following pre-installation steps to provide the controller any credentials and authentication context it needs to interact with the AWS API.
 
-Configuration and authentication in OpenShift requires the use of IAM users and policies. Authentication credentials are set inside a `ConfigMap` and a `Secret` before installation of the controller.
+Configuration and authentication in OpenShift requires the use of IAM users and policies. Authentication credentials are set inside a `Secret` (optional if utilizing [IRSA](../irsa)) before installation of the controller.
 
 ### Step 1: Create the installation namespace
 
@@ -82,6 +82,13 @@ oc create configmap \
 --namespace ack-system \
 --from-env-file=config.txt ack-$SERVICE-user-config
 ```
+
+{{% hint type="info" title="Note" %}}
+The `Secret` is optional if [IRSA](../irsa) is intended to be used. In order to utilize IRSA, STS would have needed to be configured during cluster installation.
+There are two ways to provision an OpenShift cluster to utilize STS:
+1. [OpenShift Container Platform using manual mode for STS](https://docs.openshift.com/container-platform/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html)
+2. [Red Hat OpenShift Service on AWS](https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html)
+{{% /hint %}}
 
 Save another file, `secrets.txt`, with the following authentication values, which you should have saved from earlier when you created your user's access keys:
 ```bash


### PR DESCRIPTION
Issue #, if available:
N/A
Description of changes:
Adding in documentation for OpenShift users to setup IRSA (assuming they have a cluster provisioned properly). The existing IRSA documentation works top down starting from step 2, with the one change that I noted on how to obtain the OIDC_PROVIDER. 

There was also a typo in an existing command where `SERVICE` was not taking the exported value that I also updated.

This should probably be `/hold` until the below has been released and PR's to `operatorhub community` repos have been merged for a few controllers.
- Relates: aws-controllers-k8s/code-generator#353

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>