### PR TITLE
Add tutorial to restore rds db snapshot to dbinstance/cluster

### DIFF
--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -256,6 +256,50 @@ spec:
 EOF
 ```
 
+## Restore Snapshot to DBInstance or DBCluster
+
+You can restore a snapshot to DBInstance or DBCluster with setting `SnapshotIdentifier` inside `DBCluster` or `DBSnapshotIdentifier` inside `DBInstance` CRD to restore the snapshot to a DBCluster or DBInstance. 
+'SnapshotIdentifier' need match the existing DBCluster snapshot identifier or ARN of DBInstance snapshot, `DBSnapshotIdentifier` need match the identifier of an existing DBSnapshot. 
+Once it's set and resource created, update them will have no effect. You can use the following example to restore a DBSnapshot to DBCluster: 
+
+```bash
+cat <<EOF > rds-restore-dbcluster-snapshot.yaml
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBCluster
+metadata:
+  name: "${RDS_CLUSTER_NAME}"
+spec:
+  dbClusterIdentifier: "${RDS_CLUSTER_NAME}"
+  engine: aurora-postgresql
+  engineVersion: "13.7"
+  snapshotIdentifier: arn:aws:rds:${RDS_REGION}:${RDS_CUSTOMER_ACCOUNT}:snapshot:${RDS_DB_SNAPSHOT_IDENTIFIER}
+EOF
+
+kubectl apply -f rds-restore-dbcluster-snapshot.yaml
+```
+
+Example to restore a DBSnapshot to DBInstance:
+
+```bash
+cat <<EOF > rds-restore-dbinstance-snapshot.yaml
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBInstance
+metadata:
+  name: "${RDS_INSTANCE_NAME}"
+spec:
+  allocatedStorage: 20
+  dbInstanceClass: db.m5.large
+  dbInstanceIdentifier: "${RDS_INSTANCE_NAME}"
+  engine: postgres
+  engineVersion: "14"
+  masterUsername: "postgres"
+  multiAZ: true
+  dbSnapshotIdentifier: "${RDS_DB_SNAPSHOT_IDENTIFIER}"
+EOF
+
+kubectl apply -f rds-restore-dbinstance-snapshot.yaml
+```
+
 ## Next steps
 
 You can learn more about each of the ACK service controller for RDS custom resources by using `kubectl explain` on the API resources. These include:

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -256,13 +256,24 @@ spec:
 EOF
 ```
 
-## Restore Snapshot to DBInstance or DBCluster
+## Restore a Database Snapshot
 
-You can restore a snapshot to DBInstance or DBCluster with setting `SnapshotIdentifier` inside `DBCluster` or `DBSnapshotIdentifier` inside `DBInstance` CRD to restore the snapshot to a DBCluster or DBInstance. 
-`SnapshotIdentifier` need match the existing DBCluster snapshot identifier or ARN of DBInstance snapshot, `DBSnapshotIdentifier` need match the identifier of an existing DBSnapshot. 
-Once it's set and resource created, update them will have no effect. You can use the following example to restore a DBSnapshot to DBCluster: 
+You can also restore a database snapshot to a specific `DBInstance` or `DBCluster` using the ACK for RDS controller.
+
+To restore a database snapshot to a `DBInstance`, you must set the `Spec.DBSnapshotIdentifier` parameter. `Spec.DBSnapshotIdentifier` should match the identifier of an existing DBSnapshot.
+
+To restore a database snapshot to a `DBCluster`, you must set the `Spec.SnapshotIdentifier`. The value of `Spec.SnapshotIdentifier` should match either an existing `DBCluster` snapshot identifier or an ARN of a `DBInstance`snapshot.
+
+Once it's set and the resource is created, updating `Spec.SnapshotIdentifer` or `Spec.BSnapshotIdentifier` fields will have no effect.
+
+The following examples show how you can restore database snapshots both to `DBCluster` and `DBInstance` resources:
 
 ```bash
+RDS_CLUSTER_NAME="<your cluster name>"
+RDS_REGION="<your aws region>"
+RDS_CUSTOMER_ACCOUNT="<your aws account id>"
+RDS_DB_SNAPSHOT_IDENTIFIER="<your db snapshot identifier>"
+
 cat <<EOF > rds-restore-dbcluster-snapshot.yaml
 apiVersion: rds.services.k8s.aws/v1alpha1
 kind: DBCluster
@@ -278,9 +289,10 @@ EOF
 kubectl apply -f rds-restore-dbcluster-snapshot.yaml
 ```
 
-Example to restore a DBSnapshot to DBInstance:
-
 ```bash
+RDS_INSTANCE_NAME="<your instance name>"
+RDS_DB_SNAPSHOT_IDENTIFIER="<your db snapshot identifier>"
+
 cat <<EOF > rds-restore-dbinstance-snapshot.yaml
 apiVersion: rds.services.k8s.aws/v1alpha1
 kind: DBInstance

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -256,7 +256,7 @@ spec:
 EOF
 ```
 
-## Restore a Database Snapshot
+## Create a Database from Snapshot
 
 You can also restore a database snapshot to a specific `DBInstance` or `DBCluster` using the ACK for RDS controller.
 

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -259,7 +259,7 @@ EOF
 ## Restore Snapshot to DBInstance or DBCluster
 
 You can restore a snapshot to DBInstance or DBCluster with setting `SnapshotIdentifier` inside `DBCluster` or `DBSnapshotIdentifier` inside `DBInstance` CRD to restore the snapshot to a DBCluster or DBInstance. 
-'SnapshotIdentifier' need match the existing DBCluster snapshot identifier or ARN of DBInstance snapshot, `DBSnapshotIdentifier` need match the identifier of an existing DBSnapshot. 
+`SnapshotIdentifier` need match the existing DBCluster snapshot identifier or ARN of DBInstance snapshot, `DBSnapshotIdentifier` need match the identifier of an existing DBSnapshot. 
 Once it's set and resource created, update them will have no effect. You can use the following example to restore a DBSnapshot to DBCluster: 
 
 ```bash

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -260,11 +260,11 @@ EOF
 
 You can also restore a database snapshot to a specific `DBInstance` or `DBCluster` using the ACK for RDS controller.
 
-To restore a database snapshot to a `DBInstance`, you must set the `Spec.DBSnapshotIdentifier` parameter. `Spec.DBSnapshotIdentifier` should match the identifier of an existing DBSnapshot.
+To restore a database snapshot to a `DBInstance`, you must set the `DBSnapshotIdentifier` parameter. `DBSnapshotIdentifier` should match the identifier of an existing DBSnapshot.
 
-To restore a database snapshot to a `DBCluster`, you must set the `Spec.SnapshotIdentifier`. The value of `Spec.SnapshotIdentifier` should match either an existing `DBCluster` snapshot identifier or an ARN of a `DBInstance`snapshot.
+To restore a database snapshot to a `DBCluster`, you must set the `SnapshotIdentifier`. The value of `SnapshotIdentifier` should match either an existing `DBCluster` snapshot identifier or an ARN of a `DBInstance`snapshot.
 
-Once it's set and the resource is created, updating `Spec.SnapshotIdentifer` or `Spec.BSnapshotIdentifier` fields will have no effect.
+Once it's set and the resource is created, updating `SnapshotIdentifer` or `DBSnapshotIdentifier` fields will have no effect.
 
 The following examples show how you can restore database snapshots both to `DBCluster` and `DBInstance` resources:
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add tutorial for restore rds snapshot. 
either restore Snapshot to DBCluster or restore DBSnapshot to DBInstance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
