### PR TITLE
Add summary table showing services in GA/Preview

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@3931c8ef936344ebcda21bfb133d4bfc97736d98#subdirectory=tools
+PyGitHub==1.55
 Jinja2==3.0.1

--- a/docs/scripts/templates/services.jinja2
+++ b/docs/scripts/templates/services.jinja2
@@ -33,6 +33,8 @@ release ACK service controllers.
 {{% /hint %}}
 {% endraw %}
 
+{{ services_summary_table }}
+
 {{ services_table }}
 
 {% raw %}


### PR DESCRIPTION
Adds a simple summary table to the services listing that shows the count of service controllers in GA and Dev Preview maintenance phase.

Unfortunately I cannot functionally test this code because my IAM user does not have access to read from ECR Public for the ack-infra account any longer...

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
