### PR TITLE
Update Application Autoscaling tutorial instance type

### DIFF
--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -257,7 +257,7 @@ export XGBOOST_IMAGE=683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgbo
 **IMPORTANT**: If your `SERVICE_REGION` is not `us-east-1`, you must change the `XGBOOST_IMAGE` URI. To find your region-specific XGBoost image URI, choose your region in the [SageMaker Docker Registry Paths page](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html), and then select **XGBoost (algorithm)**. For this example, use version 1.2-1.
 {{% /hint %}}
 
-Use the following `deploy.yaml` file to deploy the model on an `ml.c4.large` instance. To use your own model, change the `modelDataURL` value. 
+Use the following `deploy.yaml` file to deploy the model on an `ml.m5.large` instance. To use your own model, change the `modelDataURL` value. 
 
 ```bash
 printf '
@@ -283,7 +283,7 @@ spec:
   productionVariants:
   - modelName: '$MODEL_NAME'
     variantName: AllTraffic
-    instanceType: ml.c4.large
+    instanceType: ml.m5.large
     initialInstanceCount: 1
 ---
 apiVersion: sagemaker.services.k8s.aws/v1alpha1

--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -257,7 +257,7 @@ export XGBOOST_IMAGE=683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgbo
 **IMPORTANT**: If your `SERVICE_REGION` is not `us-east-1`, you must change the `XGBOOST_IMAGE` URI. To find your region-specific XGBoost image URI, choose your region in the [SageMaker Docker Registry Paths page](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html), and then select **XGBoost (algorithm)**. For this example, use version 1.2-1.
 {{% /hint %}}
 
-Use the following `deploy.yaml` file to deploy the model on an `ml.t2.medium` instance. To use your own model, change the `modelDataURL` value. 
+Use the following `deploy.yaml` file to deploy the model on an `ml.c4.large` instance. To use your own model, change the `modelDataURL` value. 
 
 ```bash
 printf '
@@ -283,7 +283,7 @@ spec:
   productionVariants:
   - modelName: '$MODEL_NAME'
     variantName: AllTraffic
-    instanceType: ml.t2.medium
+    instanceType: ml.c4.large
     initialInstanceCount: 1
 ---
 apiVersion: sagemaker.services.k8s.aws/v1alpha1


### PR DESCRIPTION
Issue #, if available:

Sagemaker endpoint no longer supports "t2" type instances for autoscaling, an instance of that type is currently being used in [this](https://aws-controllers-k8s.github.io/community/docs/tutorials/autoscaling-example/#deploy-a-sagemaker-endpoint) tutorial. This PR replaces it with a ml.m5.large.

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
