### PR TITLE
Sort table of contents by short name

### DIFF
--- a/docs/scripts/gen_reference.py
+++ b/docs/scripts/gen_reference.py
@@ -236,6 +236,7 @@ def main(
 
     overviews.append(generate_runtime_resources(src_parent))
 
+    service_controller_overviews: List[ServiceOverview] = []
     for controller_repo in src_parent.glob("*-controller"):
         if not controller_repo.is_dir() or \
             controller_repo.stem.startswith("template"):
@@ -260,7 +261,12 @@ def main(
         resources = write_service_pages(service, service_bases_path, page_output_path)
         overview = ServiceOverview(service, resources, metadata)
 
-        overviews.append(overview)
+        service_controller_overviews.append(overview)
+
+    # Ensure they are sorted by short name for the table of contents
+    service_controller_overviews.sort(key=lambda x: x.service_metadata.service.short_name)
+
+    overviews.extend(service_controller_overviews)
 
     write_overview_page(overviews, data_output_path)
     return 0


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1637

Description of changes:
Currently, when the scripts that generate the API reference execute, the docs are generated using the alphabetical order of the controller repositories. This places the `prometheusservice-controller` after the `organizations-controller` in the API reference table of contents. However, when rendering the ToC, they are rendered using their short name. This would require that `AMP` is after `ACM` and before `APIGWv2` in the list. This pull request sorts the list of services by their metadata "short name" before executing their templates and adding the data to the YAML.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
