### PR TITLE
docs: Add build tag information

### DIFF
--- a/docs/content/docs/contributor-docs/setup.md
+++ b/docs/content/docs/contributor-docs/setup.md
@@ -73,6 +73,15 @@ Make sure in your `$GOPATH/src` that you have directories for the
 mkdir -p $GOPATH/src/github.com/aws-controllers-k8s
 ```
 
+{{% hint type="info" title="Contributing to ACK core repositories" %}} 
+If you plan to make changes to one of the ACK core repositories e.g.,
+`code-generator `, you might see errors in your IDE, such as `Unresolved Type
+"Operation"`. This is because some packages, like
+`github.com/aws/aws-sdk-go/private/model/api` use Go build tags which some IDEs
+do not enable by default. For Goland, build tag documentation can be found
+[here](https://www.jetbrains.com/help/go/configuring-build-constraints-and-vendoring.html#configure-build-constraints-for-your-project).
+{{% /hint %}}
+
 ## `git clone` forked repositories and add upstream remote
 
 For each of your forked repositories, you will `git clone` the repository into


### PR DESCRIPTION
Description of changes:

Add note about `Unresolved Type X` errors caused by missing build tags. Discussion (Slack): https://kubernetes.slack.com/archives/C0402D8JJS1/p1675605921217409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
