### PR TITLE
Update command to retrieve Sagemaker controller version

### DIFF
--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -142,7 +142,12 @@ Get the Application Auto Scaling Helm chart and make it available on the client 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=applicationautoscaling
-export RELEASE_VERSION=v0.2.15
+export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+
+if [[ -z "$RELEASE_VERSION" ]]; then
+  RELEASE_VERSION=v1.0.2
+fi  
+
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -141,7 +141,7 @@ Get the SageMaker Helm chart and make it available on the client machine with th
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=sagemaker
-export RELEASE_VERSION=v0.5.1
+export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -142,6 +142,11 @@ Get the SageMaker Helm chart and make it available on the client machine with th
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=sagemaker
 export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+
+if [[ -z "$RELEASE_VERSION" ]]; then
+  RELEASE_VERSION=v1.2.0
+fi
+
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF


### PR DESCRIPTION
Description of changes:

Dynamically retrieve the latest version of the Sagemaker controller instead of hardcoding, script is borrowed from https://aws-controllers-k8s.github.io/community/docs/user-docs/install/.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
