### PR TITLE
Add curl as a prerequisite for Sagemaker tutorials

### DIFF
--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -32,6 +32,7 @@ This guide assumes that you have:
     - [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) - A command line tool for working with EKS clusters.
     - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [`wget` plain binary installation](https://mikefarah.gitbook.io/yq/#wget))
     - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
+    - [curl](https://everything.curl.dev/get) - A command line tool for transmitting data with URLs.
 
 ### Configure IAM permissions
 

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -29,6 +29,7 @@ This guide assumes that you have:
     - [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html) - A command line tool for working with EKS clusters.
     - [yq](https://mikefarah.gitbook.io/yq) - A command line tool for YAML processing. (For Linux environments, use the [`wget` plain binary installation](https://github.com/mikefarah/yq/#wget))
     - [Helm 3.7+](https://helm.sh/docs/intro/install/) - A tool for installing and managing Kubernetes applications.
+    - [curl](https://everything.curl.dev/get) - A command line tool for transmitting data with URLs.
 
 ### Configure IAM permissions
 


### PR DESCRIPTION
Description of changes:

Adds curl as a prerequisite since its used in the tutorials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
