### PR TITLE
Correct references to outdated `k8s.gcr.io`

### DIFF
--- a/docs/content/docs/user-docs/field-export.md
+++ b/docs/content/docs/user-docs/field-export.md
@@ -95,7 +95,7 @@ metadata:
 spec:
   containers:
   - name: field-export-demo-container
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/busybox
     command: [ "/bin/sh", "-c", "env" ]
     env:
     - name: USER_DATA_BUCKET_LOCATION


### PR DESCRIPTION
Replace with `registry.k8s.io`

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
