### PR TITLE
Remove references to v prefix in Helm charts

### DIFF
--- a/docs/content/docs/community/releases.md
+++ b/docs/content/docs/community/releases.md
@@ -135,7 +135,7 @@ will be incremented. If the commits simply fix bugs and do not introduce any
 features or interface changes, the patch version ("Z") will be incremented.
 
 Releases of any ACK component that have a zero major release number (e.g.
-`v0.0.2`) may have breaking changes to the public API or interfaces exposed by
+`0.0.2`) may have breaking changes to the public API or interfaces exposed by
 that component.
 
 This is by design, and [per the Semantic Versioning specification][semver-zero]:

--- a/docs/content/docs/contributor-docs/release.md
+++ b/docs/content/docs/contributor-docs/release.md
@@ -19,7 +19,7 @@ a ACK service controller's release artifacts.
 
 Once ACK service controller changes are tested by the service team and they wish to
 release latest artifacts, service team only needs to create a new release for service-controller
-github repository with a semver tag (Ex: v0.0.1).
+github repository with a semver tag (Ex: `0.0.1`).
 Steps below show how to create a new release with semver tag.
 
 {{% hint type="info" title="Semver" %}}
@@ -49,12 +49,12 @@ controllers:
 
 The container image is built and pushed with an image tag that indicates the
 release version for the controller along with the AWS service. For example,
-assume a release semver tag of `v0.1.0` that includes service controllers for
+assume a release semver tag of `0.1.0` that includes service controllers for
 S3 and SNS. There would be two container images built for this release, one each
 containing the ACK service controllers for S3 and SNS. The container images would
-have the following image tags: `s3-v0.1.0` and `sns-v0.1.0`. Note
+have the following image tags: `s3-0.1.0` and `sns-0.1.0`. Note
 that the full image name would be
-`public.ecr.aws/aws-controllers-k8s/controller:s3-v0.1.0`
+`public.ecr.aws/aws-controllers-k8s/s3-controller:0.1.0`
 
 The Helm chart artifact can be used to install the ACK service controller as a
 Kubernetes Deployment; the Deployment's Pod image will refer to the exact
@@ -121,7 +121,7 @@ whenever there is a code push on `stable` git branch. Follow the steps below
 to cut a stable release for an ACK controller.
 
 1) Checkout the ACK controller release which will be marked as stable.
-Example below uses s3-controller v0.0.19 release.
+Example below uses s3-controller `0.0.19` release.
 ```bash
 cd $GOSRC/github.com/aws-controllers-k8s
 export SERVICE=s3
@@ -135,8 +135,8 @@ git checkout -b stable-$STABLE_RELEASE $STABLE_RELEASE
 nomenclature of stable branch and helm chart version please read our
 [release phase guide](../../community/releases/).
 
-For the above example, replace `version: v0.0.19` inside `helm/Chart.yaml`
-with `version: v0-stable`. Without this update the postsubmit prowjob will
+For the above example, replace `version: 0.0.19` inside `helm/Chart.yaml`
+with `version: 0-stable`. Without this update the postsubmit prowjob will
 fail because validation error due to chart version mismatch.
 
 3) Commit your changes from step2

--- a/docs/content/docs/tutorials/apigatewayv2-reference-example.md
+++ b/docs/content/docs/tutorials/apigatewayv2-reference-example.md
@@ -50,7 +50,7 @@ aws ecr-public get-login-password --region us-east-1 | helm registry login --use
 Deploy the ACK service controller for Amazon APIGatewayv2 using the [apigatewayv2-chart Helm chart](https://gallery.ecr.aws/aws-controllers-k8s/apigatewayv2-chart). Resources should be created in the `us-east-1` region:
 
 ```bash
-helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/apigatewayv2-chart --version=v0.0.17 --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/apigatewayv2-chart --version=0.0.17 --generate-name --set=aws.region=us-east-1
 ```
 
 For a full list of available values to the Helm chart, please [review the values.yaml file](https://github.com/aws-controllers-k8s/apigatewayv2-controller/blob/main/helm/values.yaml).

--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -143,10 +143,10 @@ Get the Application Auto Scaling Helm chart and make it available on the client 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=applicationautoscaling
-export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 
 if [[ -z "$RELEASE_VERSION" ]]; then
-  RELEASE_VERSION=v1.0.2
+  RELEASE_VERSION=1.0.2
 fi  
 
 export CHART_EXPORT_PATH=/tmp/chart

--- a/docs/content/docs/tutorials/emr-on-eks-example.md
+++ b/docs/content/docs/tutorials/emr-on-eks-example.md
@@ -84,7 +84,7 @@ eksctl create iamidentitymapping \
 Now we can go ahead and install EMR on EKS controller. First, let's export environment variables needed for setup
 ```
 export SERVICE=emrcontainers
-export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 export ACK_SYSTEM_NAMESPACE=ack-system
 ```
 We cam use Helm for the installation
@@ -104,7 +104,7 @@ REVISION: 1
 TEST SUITE: None
 NOTES:
 emrcontainers-chart has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/emrcontainers-controller:v0.0.6".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/emrcontainers-controller:0.0.6".
 
 Check its status by running:
   kubectl --namespace ack-system get pods -l "app.kubernetes.io/instance=ack-emrcontainers-controller"

--- a/docs/content/docs/tutorials/memorydb-example.md
+++ b/docs/content/docs/tutorials/memorydb-example.md
@@ -46,7 +46,7 @@ You can install the Helm chart to deploy the ACK service controller for Amazon M
 For example, to specify that the Amazon MemoryDB API calls go to the `us-east-1` region, you can deploy the service controller with the following command:
 
 ```bash
-helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/memorydb-chart --version=v1.0.0 --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/memorydb-chart --version=1.0.0 --generate-name --set=aws.region=us-east-1
 ```
 You can find the latest version of ACK MemoryDB controller on GitHub [release page](https://github.com/aws-controllers-k8s/memorydb-controller/releases).
 Replace value for `--version` to the desired version.

--- a/docs/content/docs/tutorials/rds-example.md
+++ b/docs/content/docs/tutorials/rds-example.md
@@ -51,7 +51,7 @@ You can now use the Helm chart to deploy the ACK service controller for Amazon R
 For example, to specify that the RDS API calls go to the `us-east-1` region, you can deploy the service controller with the following command:
 
 ```bash
-helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v0.0.27 --generate-name --set=aws.region=us-east-1
+helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=0.0.27 --generate-name --set=aws.region=us-east-1
 ```
 
 For a full list of available values to the Helm chart, please [review the values.yaml file](https://github.com/aws-controllers-k8s/rds-controller/blob/main/helm/values.yaml).

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -142,7 +142,7 @@ Get the SageMaker Helm chart and make it available on the client machine with th
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=sagemaker
-export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 
 if [[ -z "$RELEASE_VERSION" ]]; then
   RELEASE_VERSION=v1.2.0

--- a/docs/content/docs/user-docs/ack-tags.md
+++ b/docs/content/docs/user-docs/ack-tags.md
@@ -20,7 +20,7 @@ controller will automatically ensure are on all resources that it manages.
 
 The two default tags added by ACK controller are `services.k8s.aws/controller-version`
 and `services.k8s.aws/namespace`. The *controller-version* tag value is the name of
-corresponding AWS service and version for that controller(Ex: `s3-v0.1.3`).
+corresponding AWS service and version for that controller(Ex: `s3-0.1.3`).
 And the *namespace* tag value is the Kubernetes namespace for the ACK
 resource.(Ex: `default`)
 
@@ -56,7 +56,7 @@ aws ecr list-tags-for-resource --resource-arn arn:aws:ecr:us-west-2:************
     "tags": [
         {
             "Key": "services.k8s.aws/controller-version",
-            "Value": "ecr-v0.1.4"
+            "Value": "ecr-0.1.4"
         },
         {
             "Key": "first",

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -42,7 +42,7 @@ Before installing a Helm chart, you can query the controller repository to find 
 
 ```bash
 export SERVICE=s3
-export RELEASE_VERSION=`curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4`
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
 export ACK_SYSTEM_NAMESPACE=ack-system
 export AWS_REGION=us-west-2
 
@@ -81,8 +81,8 @@ helm list --namespace $ACK_SYSTEM_NAMESPACE -o yaml
 The `helm list` command should return your newly-deployed Helm chart release information:
 
 ```bash
-app_version: v0.1.1
-chart: s3-chart-v0.1.1
+app_version: 0.1.1
+chart: s3-chart-0.1.1
 name: ack-s3-controller
 namespace: ack-system
 revision: "1"


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1715

Description of changes:
This pull request removes all references to Helm charts and images prefixed with `v`. Some parts of the release documentation still reference mono-repo style image tags. For those parts, I have partially updated them where applicable, but honestly they need to be entirely rewritten to match the current structure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
