### PR TITLE
Bump the commit hash of the `acktools` used to generated docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@3fed924a7a4071723b942fc33e5c1e22cec089dd#subdirectory=tools
+acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@bc1bca9f029abb8fe8ffeafccdac821ccee6af42#subdirectory=tools
 PyGitHub==1.55
 Jinja2==3.0.1


### PR DESCRIPTION
Pull in the code fix in https://github.com/aws-controllers-k8s/test-infra/pull/360 to fix the generation of the Services page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
