### PR TITLE
Fix `RELEASE_VERSION`: strip leading "v"

### DIFF
--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -42,7 +42,7 @@ Before installing a Helm chart, you can query the controller repository to find 
 
 ```bash
 export SERVICE=s3
-export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4 | sed 's/^v//')
 export ACK_SYSTEM_NAMESPACE=ack-system
 export AWS_REGION=us-west-2
 


### PR DESCRIPTION
Description of changes:

Without this change:

```
+ helm registry login --username AWS --password-stdin public.ecr.aws
Login Succeeded
+ helm install --create-namespace -n ack-system ack-rds-controller oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=v1.1.5 --set=aws.region=us-east-1
Error: INSTALLATION FAILED: public.ecr.aws/aws-controllers-k8s/rds-chart:v1.1.5: not found
```

With this change:

```
+ helm registry login --username AWS --password-stdin public.ecr.aws
Login Succeeded
+ helm install --create-namespace -n ack-system ack-rds-controller oci://public.ecr.aws/aws-controllers-k8s/rds-chart --version=1.1.5 --set=aws.region=us-east-1
Pulled: public.ecr.aws/aws-controllers-k8s/rds-chart:1.1.5
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
