### PR TITLE
Fix the release version script for all tutorials

### DIFF
--- a/docs/content/docs/tutorials/aurora-serverless-v2.md
+++ b/docs/content/docs/tutorials/aurora-serverless-v2.md
@@ -50,9 +50,9 @@ To manage an Aurora Serverless v2 cluster from Kubernetes / Amazon EKS, you will
 
 Define environment variables
 
-```
+```bash
 SERVICE=rds
-RELEASE_VERSION=$(curl -sL "https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
+RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 ACK_SYSTEM_NAMESPACE=ack-system
 AWS_REGION=<ADD-REGION-HERE>
 ```

--- a/docs/content/docs/tutorials/autoscaling-example.md
+++ b/docs/content/docs/tutorials/autoscaling-example.md
@@ -143,7 +143,7 @@ Get the Application Auto Scaling Helm chart and make it available on the client 
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=applicationautoscaling
-export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 
 if [[ -z "$RELEASE_VERSION" ]]; then
   RELEASE_VERSION=1.0.2

--- a/docs/content/docs/tutorials/ec2-example.md
+++ b/docs/content/docs/tutorials/ec2-example.md
@@ -46,7 +46,7 @@ Install Helm chart:
 ```bash
 export SERVICE=ec2
 export AWS_REGION=<aws region id>
-export RELEASE_VERSION=$(curl -sL "https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/ec2-chart "--version=${RELEASE_VERSION}" --generate-name --set=aws.region=${AWS_REGION}
 ```
 

--- a/docs/content/docs/tutorials/emr-on-eks-example.md
+++ b/docs/content/docs/tutorials/emr-on-eks-example.md
@@ -82,9 +82,9 @@ eksctl create iamidentitymapping \
 ```
 ## Install emrcontainers-controller in your EKS cluster
 Now we can go ahead and install EMR on EKS controller. First, let's export environment variables needed for setup
-```
+```bash
 export SERVICE=emrcontainers
-export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 export ACK_SYSTEM_NAMESPACE=ack-system
 ```
 We cam use Helm for the installation

--- a/docs/content/docs/tutorials/lambda-oci-example.md
+++ b/docs/content/docs/tutorials/lambda-oci-example.md
@@ -45,7 +45,7 @@ Deploy the ACK service controller for Amazon Lambda using the [lambda-chart Helm
 
 ```bash
 SERVICE=lambda
-RELEASE_VERSION=$(curl -sL "https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
+RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 helm install --create-namespace -n ack-system oci://public.ecr.aws/aws-controllers-k8s/lambda-chart "--version=${RELEASE_VERSION}" --generate-name --set=aws.region=us-west-2
 ```
 

--- a/docs/content/docs/tutorials/sagemaker-example.md
+++ b/docs/content/docs/tutorials/sagemaker-example.md
@@ -142,7 +142,7 @@ Get the SageMaker Helm chart and make it available on the client machine with th
 ```bash
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=sagemaker
-export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 
 if [[ -z "$RELEASE_VERSION" ]]; then
   RELEASE_VERSION=v1.2.0

--- a/docs/content/docs/user-docs/install.md
+++ b/docs/content/docs/user-docs/install.md
@@ -42,7 +42,7 @@ Before installing a Helm chart, you can query the controller repository to find 
 
 ```bash
 export SERVICE=s3
-export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/$SERVICE-controller/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+export RELEASE_VERSION=$(curl -sL https://api.github.com/repos/aws-controllers-k8s/${SERVICE}-controller/releases/latest | jq -r '.tag_name | ltrimstr("v")')
 export ACK_SYSTEM_NAMESPACE=ack-system
 export AWS_REGION=us-west-2
 


### PR DESCRIPTION
Description of changes:
Update the documentation to correctly strip the `v` prefix from all tag names, so that they match the structure of the image tags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
