### PR TITLE
Fix `docs-release` prow job

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@bc1bca9f029abb8fe8ffeafccdac821ccee6af42#subdirectory=tools
+acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@371852014efcb8c26c454f861eb546c93a48f205#subdirectory=tools
 PyGitHub==1.55
 Jinja2==3.0.1


### PR DESCRIPTION
Similarly to what happened to our e2e prow jobs, doc releases are
failing because they are pointing to an old version of `acktest`

This patch fixes that by pointing to the most recent ack-test commit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
