### PR TITLE
updating OpenShift install docs to include leader election env vars

### DIFF
--- a/docs/content/docs/user-docs/openshift.md
+++ b/docs/content/docs/user-docs/openshift.md
@@ -72,6 +72,8 @@ ACK_WATCH_NAMESPACE=
 AWS_REGION=us-west-2
 AWS_ENDPOINT_URL=
 ACK_RESOURCE_TAGS=hellofromocp
+ENABLE_LEADER_ELECTION=true
+LEADER_ELECTION_NAMESPACE=
 ```
 
 Now use `config.txt` to create a `ConfigMap` in your OpenShift cluster:


### PR DESCRIPTION
Issue #, if available:
- Relates: aws-controllers-k8s/code-generator#455

Description of changes:
Adding these env's to the configmap so when leader election code is merged, installs on OpenShift can still function properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
