### PR TITLE
Simpler argument handling for debug flag

### DIFF
--- a/docs/scripts/gen_services.py
+++ b/docs/scripts/gen_services.py
@@ -170,7 +170,7 @@ def main(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate documentation service release phase pages")
-    parser.add_argument("--debug", type=bool, default=False,
+    parser.add_argument("--debug", action=argparse.BooleanOptionalAction,
         help="Enables debugging logging")
     parser.add_argument("--page_output_path", type=str, default="./content/docs/community",
         help="Relative path to the documentation output directory, relative to the `docs` directory")


### PR DESCRIPTION
supports direct assignment with --debug=False or --debug=True, but will also support --debug to set True or --no-debug to set False. Default value if not set is false.

Issue #, if available: N/A

Description of changes: removes default false value and adds builtin argparse.BooleanOptionalAction to the debug flag action.

From https://docs.python.org/dev/library/argparse.html#action : 
> "New in version 3.8.
> 
> You may also specify an arbitrary action by passing an Action subclass or other object that implements the same interface. The BooleanOptionalAction is now available in argparse and adds support for boolean actions such as --foo and --no-foo"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
