### PR TITLE
adding RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS to openshift install docs

### DIFF
--- a/docs/content/docs/user-docs/openshift.md
+++ b/docs/content/docs/user-docs/openshift.md
@@ -74,6 +74,7 @@ AWS_ENDPOINT_URL=
 ACK_RESOURCE_TAGS=hellofromocp
 ENABLE_LEADER_ELECTION=true
 LEADER_ELECTION_NAMESPACE=
+RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS=1
 ```
 
 Now use `config.txt` to create a `ConfigMap` in your OpenShift cluster:


### PR DESCRIPTION
Issue #, if available:
NA
Description of changes:
With the addition of the new flag `--reconcile-default-max-concurrent-syncs`, the OCP `ConfigMap` instructions need to be updated to include this environment variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
