### PR TITLE
Fix typo in field-export.md

### DIFF
--- a/docs/content/docs/user-docs/field-export.md
+++ b/docs/content/docs/user-docs/field-export.md
@@ -84,7 +84,7 @@ data:
 
 The `ConfigMap` data contains a new key-value pair. The key is the namespace and
 name of the `FieldExport` that created it, and the value is the resolved value
-from the resourc. This value can then be included as an environment variable in
+from the resource. This value can then be included as an environment variable in
 a pod like so:
 
 ```yaml


### PR DESCRIPTION
Issue #, if available:

Description of changes: Fix typo `resourc` -> `resource`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
