### PR TITLE
docs: fix broken link to resource adoption documentation

### DIFF
--- a/docs/content/docs/user-docs/adopted-resource.md
+++ b/docs/content/docs/user-docs/adopted-resource.md
@@ -10,8 +10,10 @@ weight: 66
 toc: true
 ---
 
-**WARNING** This is no longer the recommended approach for adopting resources.
-The recommended feature can be found [HERE](features#resourceadoption)
+{{% hint type="warning" title="Warning" %}}
+This is no longer the recommended approach for adopting resources in ACK. The
+recommended feature can be found [HERE](../user-docs/features.md#resourceadoption)
+{{% /hint %}}
 
 The ACK controllers are intended to manage the complete lifecycle of an AWS
 resource, from creation through deletion. However, you may already be


### PR DESCRIPTION
Update relative path to correctly point to feature gate documentation. Also
improve warning format by converting plain text to warning block.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
