### PR TITLE
Removed typo in policy (extra y)

### DIFF
--- a/docs/content/docs/user-docs/features.md
+++ b/docs/content/docs/user-docs/features.md
@@ -13,7 +13,7 @@ toc: true
 Currently we support 4 feature gates for our controllers.
 
 ### ResourceAdoption
-This feature allows users to adopt AWS resources by specifying the adoption policy as an annotation `services.k8s.aws/adoption-policyy` (currently only supporting `adopt` as a value), and providing the fields required for a read operation in an annotation called `services.k8s.aws/adoption-fields` in json format, and an empty spec.
+This feature allows users to adopt AWS resources by specifying the adoption policy as an annotation `services.k8s.aws/adoption-policy` (currently only supporting `adopt` as a value), and providing the fields required for a read operation in an annotation called `services.k8s.aws/adoption-fields` in json format, and an empty spec.
 Here's an example for how to adopt an EKS cluster:
 
 ```yaml


### PR DESCRIPTION
Description of changes:

There was a small typo in the documentation that had an extra `y` in the markdown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
