### PR TITLE
adding FEATURE_FLAGS to openshift install configmap values

### DIFF
--- a/docs/content/docs/user-docs/openshift.md
+++ b/docs/content/docs/user-docs/openshift.md
@@ -75,6 +75,7 @@ ACK_RESOURCE_TAGS=hellofromocp
 ENABLE_LEADER_ELECTION=true
 LEADER_ELECTION_NAMESPACE=
 RECONCILE_DEFAULT_MAX_CONCURRENT_SYNCS=1
+FEATURE_FLAGS=
 ```
 
 Now use `config.txt` to create a `ConfigMap` in your OpenShift cluster:


### PR DESCRIPTION
Issue #, if available:
- Fixes: #2252

Description of changes:
Updating the OpenShift install configmap values to include `FEATURE_FLAGS` env.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
