### PR TITLE
Update ackdiscover version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@0585d0671b593e1b1a1d070614af41eb022c695a#subdirectory=tools
+acktools @ git+https://github.com/aws-controllers-k8s/test-infra.git@817a75417079e595b394e175c1463ebcec958f97#subdirectory=tools
 PyGitHub==1.55
 Jinja2==3.0.1


### PR DESCRIPTION
Issue #, if available: [2501](https://github.com/aws-controllers-k8s/community/issues/2501)

Description of changes:
- Update docs scripts to use ackdiscover version with fixes for discovery of Bedrock Agent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
