### PR TITLE
doc: update branch name from master to main in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ When filing an issue, please check existing open, or recently closed, issues to 
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

While reviewing the CONTRIBUTING.md file for contribution, I noticed it incorrectly says to fork the `master` branch, when what it probably means is `main` branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
