### PR TITLE
fix: skip attaching role policies if they do not exist

### DIFF
--- a/docs/content/docs/user-docs/irsa.md
+++ b/docs/content/docs/user-docs/irsa.md
@@ -133,6 +133,9 @@ INLINE_POLICY_URL=${BASE_URL}/config/iam/recommended-inline-policy
 INLINE_POLICY="$(wget -qO- ${INLINE_POLICY_URL})"
 
 while IFS= read -r POLICY_ARN; do
+    if [ -z "$POLICY_ARN" ]; then
+        continue
+    fi
     echo -n "Attaching $POLICY_ARN ... "
     aws iam attach-role-policy \
         --role-name "${ACK_CONTROLLER_IAM_ROLE}" \


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

The IAM controller is one example where there is no recommended-policy-arn, which causes the `aws iam attach-role-policy` command to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
