### PR TITLE
Add deprecation banners and redirects to guide users to the new docs site

### DIFF
--- a/docs/data/deprecation.yaml
+++ b/docs/data/deprecation.yaml
@@ -1,0 +1,50 @@
+# Deprecation configuration for ACK community docs
+# Maps old pages to their equivalents on the new docs site
+
+# Base URL of the new documentation site
+new_site_base_url: "https://aws-controllers-k8s.github.io/docs"
+
+# Default deprecation message (used when no new_url is available)
+default_message: "This documentation site is deprecated. Please visit the new ACK documentation site for up-to-date information."
+
+# Pages that should show a warning banner with link to new equivalent (no redirect)
+# Only top-level pages - sub-pages with mappings redirect directly
+page_mappings:
+  "docs/community/overview": "/intro/"
+  "docs/community/how-it-works": "/concepts/"
+
+# Pages that should redirect directly (302) to new site
+redirects:
+  # API Reference
+  "reference": "/api-reference/"
+
+  # Services -> Controllers
+  "services": "/controllers/"
+
+  # User Documentation (sub-pages redirect)
+  "docs/user-docs/install": "/getting-started/"
+  "docs/user-docs/resource-crud": "/guides/create-resource/"
+  "docs/user-docs/ack-tags": "/guides/tags/"
+  "docs/user-docs/adopted-resource": "/guides/adoption/"
+  "docs/user-docs/authentication": "/guides/permissions/"
+  "docs/user-docs/authorization": "/guides/permissions/"
+  "docs/user-docs/cross-account-resource-management": "/guides/cross-account/"
+  "docs/user-docs/deletion-policy": "/guides/deletion-policy/"
+  "docs/user-docs/drift-recovery": "/guides/drift/"
+  "docs/user-docs/field-export": "/guides/field-export/"
+  "docs/user-docs/irsa": "/guides/configure-iam/"
+  "docs/user-docs/leader-election": "/guides/leader-election/"
+  "docs/user-docs/multi-region-resource-management": "/guides/multi-region/"
+
+# Pages without equivalents (will show generic deprecation message)
+# These are explicitly listed for documentation purposes
+no_equivalent:
+  - "docs/user-docs/cleanup"
+  - "docs/user-docs/features"
+  - "docs/user-docs/openshift"
+  - "docs/contributor-docs/*"
+  - "docs/community/background"
+  - "docs/community/discussions"
+  - "docs/community/faq"
+  - "docs/community/releases"
+  - "docs/tutorials/*"

--- a/docs/data/overview/services.yaml
+++ b/docs/data/overview/services.yaml
@@ -1,0 +1,4 @@
+# Placeholder for service overview data
+# This file is required for the reference menu to render
+# Services data is typically auto-generated
+[]

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -15,6 +15,7 @@
   <body class="{{ .Scratch.Get "class" }} d-flex flex-column h-100 dark">
     {{ partial "header/header.html" . }}
     <div class="wrap container" role="document">
+      {{ partial "deprecation-banner.html" . }}
       <div class="content">
         {{ block "main" . }}{{ end }}
       </div>

--- a/docs/layouts/index.redirects
+++ b/docs/layouts/index.redirects
@@ -1,6 +1,15 @@
 # redirects for Netlify - https://www.netlify.com/docs/redirects/
+# Page aliases
 {{- range $p := .Site.Pages -}}
 {{- range .Aliases }}
 {{ . }} {{ $p.RelPermalink -}}
 {{- end }}
+{{- end }}
+
+# Deprecation redirects to new documentation site
+{{- $deprecation := .Site.Data.deprecation -}}
+{{- $newSiteBase := $deprecation.new_site_base_url -}}
+{{- range $oldPath, $newPath := $deprecation.redirects }}
+/{{ $oldPath }}/ {{ $newSiteBase }}{{ $newPath }} 302
+/{{ $oldPath }} {{ $newSiteBase }}{{ $newPath }} 302
 {{- end -}}

--- a/docs/layouts/partials/deprecation-banner.html
+++ b/docs/layouts/partials/deprecation-banner.html
@@ -1,0 +1,135 @@
+{{- /* Deprecation banner - shows warning on all pages */ -}}
+{{- with .Site.Data.deprecation -}}
+  {{- $newSiteBase := .new_site_base_url -}}
+  {{- $currentPath := $.RelPermalink | replaceRE "^/" "" | replaceRE "/$" "" -}}
+
+  {{- /* Check if this page should redirect */ -}}
+  {{- $shouldRedirect := false -}}
+  {{- $redirectUrl := "" -}}
+  {{- range $oldPath, $newPath := .redirects -}}
+    {{- /* Match exact path or prefix (for sections like reference/*) */ -}}
+    {{- if or (eq $currentPath $oldPath) (hasPrefix $currentPath (printf "%s/" $oldPath)) -}}
+      {{- $shouldRedirect = true -}}
+      {{- $redirectUrl = printf "%s%s" $newSiteBase $newPath -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if $shouldRedirect -}}
+    {{- /* Show redirect notice with JS fallback */ -}}
+    <script>window.location.href = "{{ $redirectUrl }}";</script>
+    <noscript>
+    <div class="deprecation-banner deprecation-redirect" role="alert">
+      <div class="deprecation-icon">&#x26A0;</div>
+      <div class="deprecation-content">
+        <strong>Redirecting...</strong>
+        <p>This page has moved. <a href="{{ $redirectUrl }}">Click here</a> if you are not redirected automatically.</p>
+      </div>
+    </div>
+    </noscript>
+  {{- else -}}
+    {{- /* Check if this page has a mapped equivalent */ -}}
+    {{- $newUrl := "" -}}
+    {{- range $oldPath, $newPath := .page_mappings -}}
+      {{- if eq $currentPath $oldPath -}}
+        {{- $newUrl = printf "%s%s" $newSiteBase $newPath -}}
+      {{- end -}}
+    {{- end -}}
+
+    <div class="deprecation-banner" role="alert">
+      <div class="deprecation-icon">&#x26A0;</div>
+      <div class="deprecation-content">
+        <strong>This documentation site is deprecated.</strong>
+        {{- if $newUrl }}
+        <p>This page has moved to the new documentation site. <a href="{{ $newUrl }}">View the updated version</a>.</p>
+        {{- else }}
+        <p>Please visit the <a href="{{ $newSiteBase }}">new ACK documentation site</a> for up-to-date information.</p>
+        {{- end }}
+      </div>
+    </div>
+  {{- end -}}
+{{- end -}}
+
+<style>
+.deprecation-banner {
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-left: 4px solid #3b82f6;
+  border-radius: 4px;
+  padding: 12px 16px;
+  margin: 0 0 20px 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.deprecation-banner.deprecation-redirect {
+  border-left-color: #10b981;
+}
+
+.deprecation-icon {
+  font-size: 18px;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
+.deprecation-content {
+  flex: 1;
+}
+
+.deprecation-content strong {
+  color: #1e293b;
+  font-size: 14px;
+}
+
+.deprecation-redirect .deprecation-content strong {
+  color: #065f46;
+}
+
+.deprecation-content p {
+  margin: 4px 0 0 0;
+  color: #475569;
+  font-size: 13px;
+}
+
+.deprecation-redirect .deprecation-content p {
+  color: #065f46;
+}
+
+.deprecation-content a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.deprecation-content a:hover {
+  text-decoration: underline;
+}
+
+/* Dark mode support */
+.dark .deprecation-banner {
+  background: #1e293b;
+  border-color: #475569;
+  border-left-color: #60a5fa;
+}
+
+.dark .deprecation-content strong {
+  color: #f1f5f9;
+}
+
+.dark .deprecation-content p {
+  color: #94a3b8;
+}
+
+.dark .deprecation-content a {
+  color: #60a5fa;
+}
+
+.dark .deprecation-banner.deprecation-redirect {
+  border-left-color: #34d399;
+}
+
+.dark .deprecation-redirect .deprecation-content strong,
+.dark .deprecation-redirect .deprecation-content p {
+  color: #a7f3d0;
+}
+</style>

--- a/docs/layouts/partials/deprecation-redirect-head.html
+++ b/docs/layouts/partials/deprecation-redirect-head.html
@@ -1,0 +1,13 @@
+{{- /* This partial outputs redirect meta tags for the head section */ -}}
+{{- with .Site.Data.deprecation -}}
+  {{- $newSiteBase := .new_site_base_url -}}
+  {{- $currentPath := $.RelPermalink | replaceRE "^/" "" | replaceRE "/$" "" -}}
+  {{- range $oldPath, $newPath := .redirects -}}
+    {{- /* Match exact path or prefix (for sections like reference/*) */ -}}
+    {{- if or (eq $currentPath $oldPath) (hasPrefix $currentPath (printf "%s/" $oldPath)) -}}
+      {{- $redirectUrl := printf "%s%s" $newSiteBase $newPath -}}
+  <meta http-equiv="refresh" content="0; url={{ $redirectUrl }}">
+  <link rel="canonical" href="{{ $redirectUrl }}">
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/docs/layouts/partials/head/head.html
+++ b/docs/layouts/partials/head/head.html
@@ -7,4 +7,5 @@
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}
   {{ block "head/favicons" . }}{{ partial "head/favicons.html" . }}{{ end }}
   {{ block "head/script-header" . }}{{ partial "head/script-header.html" . }}{{ end }}
+  {{ partial "deprecation-redirect-head.html" . }}
 </head>


### PR DESCRIPTION
at https://aws-controllers-k8s.github.io/docs.

- Add deprecation banner to all pages with link to new equivalent when available
- Configure 302 redirects for:
  - `/reference/*` → `/api-reference/`
  - `/services/*` → `/controllers/`
  - `/docs/user-docs/*` pages with known equivalents
- Top-level pages (overview, how-it-works) show banner only, no redirect
- Pages without equivalents show generic deprecation message
- Banner styled with clean blue/slate theme, dark mode support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
