### PR TITLE
ignore generating status fields if not defined

### DIFF
--- a/docs/scripts/gen_reference.py
+++ b/docs/scripts/gen_reference.py
@@ -142,10 +142,11 @@ def convert_crd_to_resource(crd: Dict, service: str, crd_package_path: str = "")
         res_spec.append(convert_field(field_name, field, required))
 
     status = schema['properties']['status']
-    status_properties = status['properties']
-    for field_name, field in status_properties.items():
-        required  = field_name in status['required'] if 'required' in status else False
-        res_status.append(convert_field(field_name, field, required))
+    if 'properties' in status:
+        status_properties = status['properties']
+        for field_name, field in status_properties.items():
+            required  = field_name in status['required'] if 'required' in status else False
+            res_status.append(convert_field(field_name, field, required))
 
     return Resource(
         name=crd['spec']['names']['kind'],


### PR DESCRIPTION
Description of changes:
IAMRoleSelector, a CRD we recently released, does not contain any status properties.
https://github.com/aws-controllers-k8s/runtime/blob/main/apis/core/v1alpha1/iam_role_selector.go#L44

This was causing our doc generator script to fail when trying to lookup the status field
https://prow.ack.aws.dev/view/s3/ack-prow-logs/logs/docs-release/1988588645384196096

With these changes, we make status fields optional

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
