### PR TITLE
fix: Enable jinja2 autoescape in doc generators

### DIFF
--- a/docs/scripts/gen_reference.py
+++ b/docs/scripts/gen_reference.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from dataclasses import dataclass, asdict
 from typing import Dict, List, Optional, Union
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from jinja2.loaders import FileSystemLoader
 
 @dataclass(frozen=True)
@@ -180,7 +180,7 @@ def write_service_pages(
         page_path = page_output_path / resource.output_path(service)
         page_path.parent.mkdir(parents=True, exist_ok=True)
 
-        env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), trim_blocks=True, lstrip_blocks=True)
+        env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), trim_blocks=True, lstrip_blocks=True, autoescape=select_autoescape())
         template = env.get_template("resource.jinja2")
         with open(page_path, "w") as out:
             print(template.render(asdict(resource)), file=out)

--- a/docs/scripts/gen_services.py
+++ b/docs/scripts/gen_services.py
@@ -10,7 +10,7 @@ import sys
 import github
 import prettytable
 from dataclasses import dataclass, asdict
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from jinja2.loaders import FileSystemLoader
 from pathlib import Path
 from typing import List, Mapping, NewType
@@ -29,7 +29,7 @@ class TemplateArgs:
     controllers: Mapping[str, controller.Controller] # Maps from service package name to controller
 
 def write_services_page(args: TemplateArgs, page_output_path: Path):
-    env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), trim_blocks=True, lstrip_blocks=True)
+    env = Environment(loader=FileSystemLoader(Path(__file__).parent / 'templates'), trim_blocks=True, lstrip_blocks=True, autoescape=select_autoescape())
     template = env.get_template("services.jinja2")
     with open(page_output_path, "w") as out:
         print(template.render(asdict(args)), file=out)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Configure jinja2 Environment with autoescape=select_autoescape() in the documentation generator scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
